### PR TITLE
Implement styles for an embedded Google Form

### DIFF
--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -35,3 +35,10 @@
   margin: 20px 10px;
   display: block;
 }
+
+.google-form {
+  width: 100%;
+  height: 65vh;
+  margin-top: 50px;
+  border: none;
+}

--- a/lessons/module-1/intro-to-flexbox.md
+++ b/lessons/module-1/intro-to-flexbox.md
@@ -163,6 +163,8 @@ Dog Party Starter Kits:
 - [Top Section](https://codepen.io/ameseee/pen/zVWEEa)
 - [Bottom Section](https://codepen.io/ameseee/pen/PrRJaZ)
 
+<iframe class="google-form" src="https://docs.google.com/forms/d/e/1FAIpQLSd0js0vg5eNc1iYALt8U-L44aug8nRHwVba0f3IdSes9DBtYA/viewform?embedded=true" marginheight="0" marginwidth="0">Loading...</iframe>
+
 ## Further Exploration
 
 While you may not use the following properties as frequently, it's working reading through some documentation on them should you have a use-case in the future:


### PR DESCRIPTION
Addresses issue #368

This PR adds a CSS rule for the class `google-form` that provides consistency to the appearance of an embedded Google Form, mainly to be used for Checks For Understanding.

Students will be able to complete and submit the form directly from our curriculum site. Responses will be available as they would if forms were completed on the actual Google Form site.

To embed a Google Form in a lesson, instructors will need to start from the "Edit" Google Form page. Click the Send button in the top right corner, select the "Send via" tab with the `< >` icon, then copy the provided HTML code. Paste that code into the lesson markdown. Remove the `width`, `height`, and `frameborder` attributes. Add a class attribute of `google-form`.

The background color of the top section of the form when viewing on google will appear as a thick border-top on the embedded form. Google Forms does accept hex codes - select the palette icon for "Theme Options", the plus icon for "Add custom themes", then type in any hex code.

The screen shots below show a short form embedded into the Mod 1 Flexbox lesson, with color `#F9AE06`. The HTML for the embedded form can also be found in this PR on the same lesson.

![image](https://user-images.githubusercontent.com/25447342/60736748-50c92580-9f15-11e9-88e0-7c0637aeca9f.png)

![image](https://user-images.githubusercontent.com/25447342/60736758-59b9f700-9f15-11e9-86c0-18d4b552fa8b.png)

![image](https://user-images.githubusercontent.com/25447342/60736824-a30a4680-9f15-11e9-905c-6f3f93f3890e.png)