### PR TITLE
Remove old button style and use new button style to match turing.io site

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
   <head>
     {% include head.html %}
   </head>

--- a/_sass/buttons.scss
+++ b/_sass/buttons.scss
@@ -1,24 +1,3 @@
-button {
-  background-color: #F9F9F9;
-  border: none;
-  border-radius: 2px;
-  box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
-  padding: 20px 15px;
-  margin: 10px;
-  font-size: 1.25em;
-  color: #5F7D99;
-
-  &:hover {
-    box-shadow: 0 0 8px rgba(0, 0, 0, 0.3);
-  }
-}
-
-button.active {
-  background-color: #E0E0E0;
-  border: 1px solid #AEAEAE;
-}
-
-// This will eventually replace the button style above
 .btn {
   font-family: $bold-copy;
   font-size: 0.9em;
@@ -35,7 +14,17 @@ button.active {
   color: $light-gray;
 }
 
+.btn-dark.active {
+  background-color: $turing-secondary;
+  color: $turing-primary;
+}
+
 .btn-light {
   background-color: $light-gray;
   color: $dark-gray;
+}
+
+.btn-light.active {
+  background-color: $turing-primary;
+  color: $turing-secondary;
 }

--- a/lessons/index.html
+++ b/lessons/index.html
@@ -4,11 +4,11 @@ title: Lesson Plans
 ---
 
 <section>
-  <button class="module-selector" data-module="1">Module 1</button>
-  <button class="module-selector" data-module="2">Module 2</button>
-  <button class="module-selector" data-module="3">Module 3</button>
-  <button class="module-selector" data-module="4">Module 4</button>
-  <button class="module-selector" data-module="0">Show All</button>
+  <button class="btn btn-dark module-selector" data-module="1">Module 1</button>
+  <button class="btn btn-dark module-selector" data-module="2">Module 2</button>
+  <button class="btn btn-dark module-selector" data-module="3">Module 3</button>
+  <button class="btn btn-dark module-selector" data-module="4">Module 4</button>
+  <button class="btn btn-dark module-selector" data-module="0">Show All</button>
 </section>
 
 <section class="lesson-container" data-module="1" style="display:none">


### PR DESCRIPTION
Removed old button style for lessons `index.html` page. Replaced with new button style and added an `active` state style, which is used on the lesson index page.

Before:
![image](https://user-images.githubusercontent.com/17582916/61148479-1c68e280-a49c-11e9-8dae-e40b500f7670.png)

After:
![image](https://user-images.githubusercontent.com/17582916/61148493-27bc0e00-a49c-11e9-865d-20e625c63f6d.png)
