### PR TITLE
Change link styles

### DIFF
--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -12,6 +12,21 @@
   }
 }
 
+.content a:link, .content a:visited {
+  border-bottom: 5px solid scale-color($turing-primary, $alpha: -75%);
+  text-shadow: 1px 0px 1px #0000000d;
+  text-decoration: none;
+  transition: all 0.3s;
+  color: lighten($turing-secondary, 25%);
+  line-height: 1em;
+  display: inline-block;
+}
+
+.content a:visited {
+  color: $turing-secondary;
+  text-shadow: 0;
+}
+
 .small {
   width: 40%;
   margin: 15px 10px;


### PR DESCRIPTION
I wanted links to stand out a little bit more in the lesson plans but I’m not sure about this!! The standard Turing teal is tooooo bright, so I put a super subtle text-shadow on the links. I used the darker Turing teal (the one for the active dark buttons) for visited links. I can’t decide which I like better/if we really need both styles. The new colors look a little intense on a page like the lesson listing:

<img width="566" alt="Screen Shot 2019-07-14 at 4 49 56 PM" src="https://user-images.githubusercontent.com/856935/61190340-06078600-a658-11e9-8383-bfc0a4621c3e.png">

Because there are so many of them. But I think they look much better in the context of a lesson plan:

<img width="1031" alt="Screen Shot 2019-07-14 at 4 50 27 PM" src="https://user-images.githubusercontent.com/856935/61190346-13bd0b80-a658-11e9-90b4-b629a6915ecb.png">