### PR TITLE
Fix minor type error in an example

### DIFF
--- a/lessons/module-2/array-prototype-methods-iterators.md
+++ b/lessons/module-2/array-prototype-methods-iterators.md
@@ -239,8 +239,8 @@ Gotchas with `find` and `filter`:
 ```js
 let pets = [
   { name: 'harvey', age: 1 },
-  { name: 'julius', age: 5 },
-  { name: 'mishu', age: 5 },
+  { name: 'julius', age: 3 },
+  { name: 'mishu', age: 3 },
 ];
 
 function findThreeYearOldPets() {


### PR DESCRIPTION
This contains a minor fix in an example so age is no longer 5, but 3, as reflected elsewhere in code.

<img width="1121" alt="Screen Shot 2020-11-29 at 8 48 10 PM" src="https://user-images.githubusercontent.com/68332132/100651290-3fa36480-3313-11eb-861f-26dfd4c44f0b.png">
