### PR TITLE
Change `json` parameter name to `data`

### DIFF
--- a/lessons/module-2/network-requests-posts.md
+++ b/lessons/module-2/network-requests-posts.md
@@ -64,7 +64,7 @@ fetch(url, {
   }
 })
   .then(response => response.json())
-  .then(json => /*do something with json*/)
+  .then(data => /*do something with data*/)
   .catch(err => /*do something with the error*/);
 ```
 


### PR DESCRIPTION
Naming this parameter `json` may lead students to believe the value is JSON when it's actually a parsed JS object. Perhaps naming it `data` as is done elsewhere.

[MDN](https://developer.mozilla.org/en-US/docs/Web/API/Response/json): "Note that despite the method being named json(), the result is not JSON but is instead the result of taking JSON as input and parsing it to produce a JavaScript object."