### PR TITLE
Update TDD rubric 2 bullet

### DIFF
--- a/projects/flash-cards.md
+++ b/projects/flash-cards.md
@@ -264,7 +264,7 @@ Collaborate with instructors to personalize an extension for this project
 ### Test-Driven Development
 * 4: Application is broken into components, good use of own data, good happy and sad path testing.
 * 3: Application is well tested but does not have consistent use of beforeEach to DRY up tests, uses data files instead of creating own data, and not enough sad path testing.
-* 2: Application makes some use of tests, but the coverage is insufficient given project requirements.
+* 2: Application makes some use of tests, but the coverage is insufficient given project requirements. No use of beforeEach to DRY up tests.
 * 1: Application does not demonstrate strong use of TDD.
 
 ## Repeaters


### PR DESCRIPTION
Updated TDD rubric bullet for score of 2 to add `No use of beforeEach to DRY up tests.`

I feel like there is still a lot of ambiguity (for graders) in that section.  
- What constitutes coverage being sufficient for project requirements?

A score of 3 states: 
`3: Application is well tested but does not have consistent use of beforeEach to DRY up tests, uses data files instead of creating own data, and not enough sad path testing.`
- What constitutes 'not enough sad path testing'?  
  - If they have solid coverage but miss 2 sad paths, is that a score of 3?  Or is that a 2?

- What constitutes consistent use of beforeEach in order to get a score of 3?   
  - Would we ideally want them to use beforeEach() in all the test suites?  So using it in all test suites would be a score of 4?
  - If they only used it in one or two test suites - that would be a score of 3?
  - If they never used it - that would be a score of 2?

I dont necessarily think we need to add details and exact numbers to the rubric but it would be awesome to have those specifications/guidelines outlined in fe-keys.

I'm going to copy/paste this into the foo-mod2 channel for discussion there.