### PR TITLE
Update mental health resources page

### DIFF
--- a/mental_health/index.html
+++ b/mental_health/index.html
@@ -10,19 +10,23 @@ title: Mental Health Resources
       several resources that are available to you!
     </p>
 
-    <h3>Your instructors</h3>
-    <p>
-      If you feel comfortable reaching out to your instructors, we're always
-      happy to listen, and we can refer you to other staff members who can
-      assist you if you need further help than we can give. We also recommend joining the slack channel #health-wellness for
-      community wellness tips, reminders,
-      and events.
-    </p>
+    <h3>Mental health resources</h3>
+    <p><a href="https://docs.google.com/document/d/1yyaTXSXiy44u0HjOyCUixuIXuWzOfsUwT39SApFAvrY/edit">Google Document of many resources</a></p>
+
+    <p>It can also be helpful to find a community! Turing has many <a href="https://docs.google.com/document/d/1Z6KoqTbLQcudqybCvaHaivf0YNM73BjTNZWPOBuWDcU/edit">Student Circles</a>, which are slack channels for people (students, staff, and alumni) who share identities or interests! Examples are:</p>
+    <ul>
+      <li>Queer Qoders - for LGBTQ+ students, staff, and alumni</li>
+      <li>Black @ Turing - for Black students, staff, and alumni</li>
+      <li>Mezcla - for Latinx and Hispanic students, staff, and alumni</li>
+      <li>ADHD Brains - for students, staff, and alumni who have ADHD</li>
+      <li>and many more!</li>
+    </ul>
+    <p>You can find information about many more Circles in <a href="https://docs.google.com/document/d/1Z6KoqTbLQcudqybCvaHaivf0YNM73BjTNZWPOBuWDcU/edit">this document</a>!</p>
 
     <h3>Financial stress</h3>
     <p>
-      For financial concerns, you can reach out directly to Darren Smith on
-      Slack; he can connect you with various services (especially in the
+      For financial concerns, you can reach out directly to Tamika Shipp on
+      Slack; she can connect you with various services (especially in the
       Colorado area), or help you find services in your area, to help alleviate
       financial stressors.
     </p>


### PR DESCRIPTION
Changed information in the Mental Health Resources page:
- Added a link to the Google Doc listing mental health resources
- Removed language around going to instructors for help (not that they shouldn't but it had language that placed a very large burden on instructors)
- Added information about Student Circles, which are often a great resource for students (community, commiseration, strategies and brainstorming for managing specifically at Turing)
- Updated the Financial Concerns contact to point toward Tamika instead of Darren