### PR TITLE
Add intro slides to mod2 overview

### DIFF
--- a/lessons/index.html
+++ b/lessons/index.html
@@ -112,6 +112,7 @@ title: Lesson Plans
 
   <h3>Resources</h3>
   <ul>
+    <li class="lesson"><a href="https://docs.google.com/presentation/d/1dRGzIiihKtr1QXF-8EaeANkPB-xGHlnu3dt0eaG57NA/edit#slide=id.g1c033f9cd5_0_35">Welcome to Mod 2 (slides)</a></li>
     <li class="lesson"><a href="module-2/mod-2-repeater-hub.html">Mod 2 Repeater Hub</a></li>
   </ul>
 


### PR DESCRIPTION
Description of changes made

This PR closes: https://github.com/turingschool/front-end-curriculum/issues/607

Motivation for any changes

Consistency across mods, making intro slides available in an easy to find location

Questions that you have for a reviewer



