### PR TITLE
Update overlook project to remove OOP related items and match new rubric system

### DIFF
--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -1,9 +1,8 @@
 ---
 title: Overlook  
 length: 1 week
-tags: javascript, oop, testing
+tags: javascript, testing
 ---
-
 <!-- Final 1 week solo project for FE Mod 2 (Week 6) -->
 
 ## Background and Description
@@ -12,26 +11,41 @@ For this project, you will be building a hotel management tool for hotel custome
 
 ## Goals and Objectives
 
-- Use OOP to drive the design of the application and the code
-- Work with an API to send and receive data
-- Solidify the code review process
-- Create a robust test suite that thoroughly tests all functionality of a client-side application
+- Use object and array prototype methods to perform data manipulation
+- Create a clear and accessible user interface
+- Make network requests to retrieve data
+- Implement a robust testing suite using TDD
+- Write DRY, reusable code that follows SRP (Single Responsibility Principle)
+- Collaborate productively and professionally as a team. Ensure all team members are able to be heard and contribute throughout the project
+
 
 ## Timeline
 
 Dates and deadlines to be aware of:
 
 Day One Deliverable:
-Please submit your project [here](https://docs.google.com/forms/d/e/1FAIpQLScsgrJD22g9WnUj7-3gXMHFSPqkk9rTt86kbRTEDGfGCIMLVA/viewform?usp=sf_link){:target='blank'}
+Submit your project [here](https://docs.google.com/forms/d/e/1FAIpQLScsgrJD22g9WnUj7-3gXMHFSPqkk9rTt86kbRTEDGfGCIMLVA/viewform?usp=sf_link){:target='blank'}
 
 Tuesday, Week 6 - Project due at 12PM.
 
 # Requirements
 
+## Workflow
+You will want to submit PRs to your accountabilibuddy to:
+
+* You must give your accountabilibuddy collaboration access to your repo.
+* You must submit *at least* 2 PRs to your accountabilibuddy for review.
+* You must wait for your accountabilibuddy to review your PRs, and allow THEM to merge any PRs you submit.
+
+It is up to you to decide what changes warrant a PR – remember we want to submit PRs that have significant changes and potential for feedback. Think about what functionality you’re struggling with or have questions about or need help with. As an accountabilibuddy, you are responsible for reviewing at least 2 PRs from your partner.
+
+**Please also tag your project manager in any PR you make to your buddy.**
+
 ## Technologies
 
-* **the fetch API** to retrieve and add data
+* **Fetch API** to retrieve and add data
 * **Mocha** and **Chai** for testing your code
+* [**Webpack**](https://frontend.turing.edu/lessons/module-2/build-processes-with-npm-webpack.html)
 
 ## Initial Setup
 
@@ -60,11 +74,17 @@ All POST and DELETE requests should have the following headers:
 }
 ```
 
-Remember, a `.catch` won't necessarily run on a bad response (ie 4xx level status) from the server. Make sure you're checking your response status codes and messages if something isn't working as expected
+Remember, a `.catch` won't necessarily run on a bad response (ie 4xx level status) from the server. Make sure you're checking your response status codes and messages if something isn't working as expected.
 </section>
 
 
 ## Iterations
+
+<section class="note">
+Consider how past projects specified a 'Data' section and a 'User Stories' section throughout the iterations description. You'll noticed that you're only supplied with User Stories below. Analyze each user story to determine what data you'll need to work with and plan what functions you'll create to manipulate that data. 
+
+Don't get too caught up with polishing your dashboard too early. You'll want to focus your energies first on the data and calculation functions, and then move on to the dashboard display. Establish some kind of minimum viable product (MVP) for your dashboard look, and then polish from there
+</section>
 
 ### 1. Dashboard
 
@@ -112,7 +132,7 @@ password: overlook2021
 
 **Refer to the "Get single user" section from the endpoints table above!**
 
-### 5. Manager Interaction
+### 5. Manager Interaction (extension)
 
 Your app should now support two different types of users.  In addition to having a customer, you will now add a manager.
 
@@ -143,69 +163,85 @@ password: overlook2021
 **Refer to the endpoints table above for *deleting* a single booking**
 
 ## Testing
-You should be testing the correctness of your code throughout your project. Each JavaScript class file in your project should have its own test file.
 
-Your testing suite should test:
+You should NOT use the original data files in the data directory for testing. These are big files, to begin with, and a real-world dataset would have millions of records. That's far too big to use every time you want to run a test.
 
-* Class properties
-* Class methods
+Instead, you should create small, sample datasets that match the structure of the application data and use these for your test data. By creating this sample dataset, you will also know if your functions are working correctly because you can do the calculations by hand with a much smaller dataset.
 
-Remember to test all possible outcomes (happy/sad/etc).  Ask yourself:  
-  - What is the value of each property?  
-  - Does the method return anything?  
-  - Does the method update any properties?
-  - Are there different possible outcomes to test for based on different arguments being passed in?
+You are expected to test:
 
-You are *not expected* to test:
+All functions that do not update the DOM. This means everything in your scripts.js file should be tested.
+Remember to test all possible outcomes (happy/sad/etc). Ask yourself:
 
-* DOM manipulation / DOM manipulating methods (like `document.querySelector(...)`)
-* Fetch calls
+Does the function return anything?
+Are there different possible outcomes to test for based on different arguments being passed in?
+You are not expected to test:
 
-## Workflow
-You will want to submit PRs to your accountabilibuddy to:
-
-* You must give your accountabilibuddy collaboration access to your repo.
-* You must submit *at least* 2 PRs to your accountabilibuddy for review.
-* You must wait for your accountabilibuddy to review your PRs, and allow THEM to merge any PRs you submit.
-
-It is up to you to decide what changes warrant a PR – remember we want to submit PRs that have significant changes and potential for feedback. Think about what functionality you’re struggling with or have questions about or need help with. As an accountabilibuddy, you are responsible for reviewing at least 2 PRs from your partner.
-
-**Please also tag your project manager in any PR you make to your buddy.**
+DOM manipulation / DOM manipulating function (like document.querySelector(...))
+Fetch calls
 
 ## Accessibility
 
-* Accessibility audits should be at 100% for the dashboard.
-* A user should be able to interact with all functionality of your application by tabbing through it, no use of the trackpad
-* ARIA attributes should be utilized for any UI elements that are not understood by the screen reader
+Strive for an accessibility audit score of 100% for the dashboard.
+
+A user should be able to interact with all functionality of your application by tabbing through it, no use of the trackpad.
+
+ARIA attributes should be utilized for any UI elements that are not understood by the screen reader
 
 
-## Due Date
 
-Make sure you submit your project [here](https://docs.google.com/forms/d/e/1FAIpQLScsgrJD22g9WnUj7-3gXMHFSPqkk9rTt86kbRTEDGfGCIMLVA/viewform?usp=sf_link){:target='blank'} by **Tuesday of Week 6 at 12pm**.
+<!-- Todo -->
+## Minimum Collaboration and Professionalism Expectations
+
+- Team holds daily standups throughout project.
+- Commits are atomic and frequent, effectively documenting the evolution/progression of the application. There is no more than a 10% disparity in project contributions between teammates.
+- A project board is utilized (and updated throughout the project) with Github issues and labels.
+- Team uses branches, PRs and thorough code reviews to add new code to the main branch.
+- The README is formatted well and at a minimum contains:
+- Overview of project and goals
+- Overview of technologies used, challenges, wins, and any other reflections
+- Screenshots/gifs of your app
+- List of contributors
+- Team collaborates effectively to accomplish the shared goal. Team productively and professionally works through challenges and conflicts to ensure all team members are able to be heard and contribute throughout the project.
+- Instructors are available to offer support and guidance but conversations around what is and what is not working are expected to be led by the team members themselves.
 
 # Rubric
 
-## Specification Adherence
+For the rubric sections below, you will be scored as Wow, Yes or Not Yet depending on whether you have demonstrated competency in that area. Each section lists examples of what types of things we may be looking for as demonstrations of competency. Just as there are many ways to approach code, there are many many ways to demonstate competency. There are just some examples.
 
-* 4: The application completes all iterations above without error.
-* 3: The application completes the first 4 iterations above without error. **Note: Must be completed in order to pass.**
-* 2: The application completes the first 2 iterations and is in a usable state, but has some miscellaneous bugs.
-* 1: The application completes only the first iteration, displaying the user's data, but has no additional functionality.
+
+## Functional Expectations
+Wow: Application fulfills all requirements as well as an extension.
+Yes: Application fulfills all requirements of iterations 1-3 without bugs. **Notes: Must be completed in order to pass**
+Not Yet: Application crashes or has missing functionality or bugs.
 
 ## UI/UX & Accessibility
 
-* 4: Application has clearly had special consideration around accessibility. Lighthouse accessibility audit is at a 100% and application is fully tabbable.
-* 3: Application has many strong pages/interactions. The application can stand on its own to be used by instructor without guidance. The UI does not detract from the UX. Lighthouse accessibility audit is at least 90% and application is fully tabbable.
-* 2: The application may be confusing or difficult to use at times.  The UI is incomplete. Accessibility has been considered, but does not have strong accessible features.
-* 1: Application is confusing or difficult to use. The UI is incomplete. Accessibility has not been considered.
+* The application can stand on its own to be used by an instructor without guidance from a developer on the team.
+UI/UX is intuitive and easy to read/use
+* Helpful messaging is displayed to prevent user confusion
+For example: For example: If a user searches for a room, but none are available then a message is displayed to indicate that the search worked, nothing is broken, there just aren't any matching rooms available.
+* The Lighthouse accessibility audit score is at least 90%
+* The application is fully tabbable 
 
-## JavaScript Style & OOP
+✨WOW✨ can look like: 
+* Design is responsive across small, medium and large breakpoints
+* Special consideration was made around accessibility
 
-* 4: Application has exceptionally well-factored code with little or no duplication.  The business-logic code driving functionality is cleanly separated from rendering, view-related code.   Excellent usage of `fetch` and updates DOM based on results of network requests.  Handles all scenarios for error handling.
-* 3: Application is thoughtfully put together with some duplication.  Application is organized into classes with some misplaced logic. Business-logic code is mostly separated from view-related code.  Great usage of `fetch` and updates DOM based on results in most scenarios, but may update DOM before a network request is complete.  Handles most scenarios for error handling.
-* 2: Class methods use a mix of array and object prototypes and for loops. Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring.  Uses `fetch` effectively for `GET` but does not implement `POST`.  Has little error handling and only `console logs` errors if a network request fails.
-* 1:  Application generates syntax error or crashes during execution.  Application is not separated into classes and there is no separation of business-side logic and view-related code. Developer writes code with unnecessary variables, operations, or steps that do not increase clarity.
+## Fundamental JavaScript and Style / Fetch
 
+* Code is divided into logical components each with a clean, single responsibility
+* Array prototype methods are used to iterate instead of for loops
+* All DOM manipulation is held in the scripts.js file. No DOM manipulation occurs outside of this file.
+* Variables and functions are consistently and appropriately named
+* Code leverages JavaScript's truthy/falsey principles
+* Demonstrates efforts towards making functions pure when possible. Note: Purity is not possible for every function in a FE application. Strive for it only when it makes sense.*
+* Application implements Fetch and updates DOME based on the results of that Fetch. 
+* Most errors are handled and messages are displayed to a user when an error occurs
+
+✨WOW✨ can look like: 
+* All data manipulation is cleanly separated from rendering code. 
+* All errors are handled and messages are displayed to a user when an error occurs
 
 ## Testing
 
@@ -213,6 +249,24 @@ Make sure you submit your project [here](https://docs.google.com/forms/d/e/1FAIp
 * 3: Application is well tested but fails to cover some features and only tests for happy paths.  Tests must be passing to be considered.
 * 2: Project has sporadic use of tests at multiple levels. The application contains numerous holes in testing and/or many features are untested.  Tests must be passing to be considered.
 * 1: There is little or no evidence of testing in the application.
+
+* Tests cover most features and test for happy paths
+* Test suite is organized.
+* Each function is tested in its own it block.
+* Each path is tested in its own it block.
+* Rather than using the production data, small sample data is stored in its own file and used for testing.
+* Sample data has been crafted to create the scenarios needed for thorough testing.
+* beforeEach hook is used to DRY up test files
+* There are no failing/pending tests upon submission 
+
+✨WOW✨ can look like: 
+* All scenarios/outcomes/paths are tested for functions, including happy and sad paths.
+* Application has a robust and thorough test suite that covers all functions that do not update the dom.
+
+## Collaboration and Professionalism
+
+See "Minimum Collaboration and Professionalism Expectations" above.
+While this is not a scored rubric section, every team member is expected to fully participate, contribute, communicate and collaborate with the team throughout the entirety of this project. Failure to do so can result in an individual failing the project, even if the group/project is otherwise passing.
 
 # Evaluation
 

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -231,7 +231,7 @@ For the rubric sections below, you will be scored as Wow, Yes or Not Yet dependi
 
 * The application can stand on its own to be used by an instructor without guidance from the developer
 * UI/UX is intuitive and easy to read/use
-* Helpful messaging is displayed to prevent user confusion. For example: For example: If a user searches for a room, but none are available then a message is displayed to indicate that the search worked, nothing is broken, there just aren't any matching rooms available.
+* Helpful messaging is displayed to prevent user confusion. For example: If a user searches for a room, but none are available then a message is displayed to indicate that the search worked, nothing is broken, there just aren't any matching rooms available.
 * The Lighthouse audit tool was used to improve accessibility.
 * Users who only use keyboards can still navigate this application
 * Users who use a screen reader can still navigate this application

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -253,6 +253,7 @@ UI/UX is intuitive and easy to read/use
 * All data manipulation is cleanly separated from rendering code. 
 * Code has clearly been refactored; functions are DRY and adhere to the Single Responsibility Principle. 
 * All errors are handled and messages are displayed to a user when an error occurs
+* Effectively implements one or more closure throughout project.
 </section>
 
 <section class="answer">

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -210,6 +210,16 @@ ARIA attributes should be utilized for any UI elements that are not understood b
 
 # Rubric
 
+<section class="answer">
+### Does the project demonstrate student understanding of the learning goals & concepts?
+
+Projects will answer that question, being marked as yes, not yet, and wow. Similarly, each section of the rubric (see below) will have yes/not yet/wow markings, helping you understand your progress and growth in specific areas.
+
+The overall project outcome (yes, not yet, wow) is determined by “averaging” each section’s outcome. You can think of a “yes” being worth a 1, a “not yet” being worth a 0, and a “wow” being worth a 2.
+
+For this project, an average of 0.5 is considered a yes - a passing project that demonstrates good student understanding! An average of 1+ is considered a wow. Anything below a 0.5 is considered a not yet - a project that indicates that the concepts have not been fully understood (see note in the section below). Please note that for this project, iterations 1-3 must be completed without bugs. 
+</section>
+
 For the rubric sections below, you will be scored as Wow, Yes or Not Yet depending on whether you have demonstrated competency in that area. Each section lists examples of what types of things we may be looking for as demonstrations of competency. Just as there are many ways to approach code, there are many many ways to demonstate competency. The following examples are not checklists to complete! There are just some examples.
 
 <section class="answer">
@@ -257,7 +267,7 @@ UI/UX is intuitive and easy to read/use
 </section>
 
 <section class="answer">
-### Testing
+  <h3> things </h3>
 
 * Tests cover most features and test for happy paths
 * Test suite is organized.

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -263,7 +263,7 @@ For the rubric sections below, you will be scored as Wow, Yes or Not Yet dependi
 </section>
 
 <section class="answer">
-  <h3> things </h3>
+### Testing
 
 * Tests cover most features and test for happy paths
 * Test suite is organized.

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -192,19 +192,15 @@ A user should be able to interact with all functionality of your application by 
 ARIA attributes should be utilized for any UI elements that are not understood by the screen reader
 
 
-## Minimum Collaboration and Professionalism Expectations
+## Minimum Professionalism Expectations
 
-- Team holds daily standups throughout project.
-- Commits are atomic and frequent, effectively documenting the evolution/progression of the application. There is no more than a 10% disparity in project contributions between teammates.
+- Commits are atomic and frequent, effectively documenting the evolution/progression of the application.
 - A project board is utilized (and updated throughout the project) with Github issues and labels.
-- Team uses branches, PRs and thorough code reviews to add new code to the main branch.
+- Student uses branches, PRs and thorough code reviews to add new code to the main branch.
 - The README is formatted well and at a minimum contains:
 - Overview of project and goals
 - Overview of technologies used, challenges, wins, and any other reflections
 - Screenshots/gifs of your app
-- List of contributors
-- Team collaborates effectively to accomplish the shared goal. Team productively and professionally works through challenges and conflicts to ensure all team members are able to be heard and contribute throughout the project.
-- Instructors are available to offer support and guidance but conversations around what is and what is not working are expected to be led by the team members themselves.
 
 ---
 
@@ -234,7 +230,7 @@ For the rubric sections below, you will be scored as Wow, Yes or Not Yet dependi
 ### UI/UX & Accessibility
 
 * The application can stand on its own to be used by an instructor without guidance from a developer on the team.
-UI/UX is intuitive and easy to read/use
+* UI/UX is intuitive and easy to read/use
 * Helpful messaging is displayed to prevent user confusion. For example: For example: If a user searches for a room, but none are available then a message is displayed to indicate that the search worked, nothing is broken, there just aren't any matching rooms available.
 * The Lighthouse accessibility audit score is at least 90%
 * The application is fully tabbable 
@@ -283,11 +279,6 @@ UI/UX is intuitive and easy to read/use
 * All scenarios/outcomes/paths are tested for functions, including happy and sad paths.
 * Application has a robust and thorough test suite that covers all functions that do not update the dom.
 </section>
-
-## Collaboration and Professionalism
-
-See "Minimum Collaboration and Professionalism Expectations" above.
-While this is not a scored rubric section, every team member is expected to fully participate, contribute, communicate and collaborate with the team throughout the entirety of this project. Failure to do so can result in an individual failing the project, even if the group/project is otherwise passing.
 
 # Evaluation
 

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -49,7 +49,9 @@ It is up to you to decide what changes warrant a PR – remember we want to subm
 
 ## Initial Setup
 
-For this project, you will want to use this [Webpack Starter Kit](https://github.com/turingschool-examples/webpack-starter-kit){:target='blank'} repo. Setup instructions are in the README.  You will also need to clone down this [local server](https://github.com/turingschool-examples/overlook-api){:target='blank'} and have it running in a separate tab in your terminal each time you run your client.
+For this project, you will want to use this [Webpack Starter Kit](https://github.com/turingschool-examples/webpack-starter-kit){:target='blank'} repo. Setup instructions are in the README.  
+
+You will also need to clone down this [local server](https://github.com/turingschool-examples/overlook-api){:target='blank'} and have it running in a separate tab in your terminal each time you run your client.
 
 ### Endpoints
 
@@ -81,6 +83,7 @@ Remember, a `.catch` won't necessarily run on a bad response (ie 4xx level statu
 ## Iterations
 
 <section class="note">
+### Note
 Consider how past projects specified a 'Data' section and a 'User Stories' section throughout the iterations description. You'll noticed that you're only supplied with User Stories below. Analyze each user story to determine what data you'll need to work with and plan what functions you'll create to manipulate that data. 
 
 Don't get too caught up with polishing your dashboard too early. You'll want to focus your energies first on the data and calculation functions, and then move on to the dashboard display. Establish some kind of minimum viable product (MVP) for your dashboard look, and then polish from there
@@ -189,8 +192,6 @@ A user should be able to interact with all functionality of your application by 
 ARIA attributes should be utilized for any UI elements that are not understood by the screen reader
 
 
-
-<!-- Todo -->
 ## Minimum Collaboration and Professionalism Expectations
 
 - Team holds daily standups throughout project.
@@ -205,9 +206,11 @@ ARIA attributes should be utilized for any UI elements that are not understood b
 - Team collaborates effectively to accomplish the shared goal. Team productively and professionally works through challenges and conflicts to ensure all team members are able to be heard and contribute throughout the project.
 - Instructors are available to offer support and guidance but conversations around what is and what is not working are expected to be led by the team members themselves.
 
+---
+
 # Rubric
 
-For the rubric sections below, you will be scored as Wow, Yes or Not Yet depending on whether you have demonstrated competency in that area. Each section lists examples of what types of things we may be looking for as demonstrations of competency. Just as there are many ways to approach code, there are many many ways to demonstate competency. There are just some examples.
+For the rubric sections below, you will be scored as Wow, Yes or Not Yet depending on whether you have demonstrated competency in that area. Each section lists examples of what types of things we may be looking for as demonstrations of competency. Just as there are many ways to approach code, there are many many ways to demonstate competency. The following examples are not checklists to complete! There are just some examples.
 
 <section class="answer">
 ### Functional Expectations
@@ -222,30 +225,33 @@ For the rubric sections below, you will be scored as Wow, Yes or Not Yet dependi
 
 * The application can stand on its own to be used by an instructor without guidance from a developer on the team.
 UI/UX is intuitive and easy to read/use
-* Helpful messaging is displayed to prevent user confusion
-For example: For example: If a user searches for a room, but none are available then a message is displayed to indicate that the search worked, nothing is broken, there just aren't any matching rooms available.
+* Helpful messaging is displayed to prevent user confusion. For example: For example: If a user searches for a room, but none are available then a message is displayed to indicate that the search worked, nothing is broken, there just aren't any matching rooms available.
 * The Lighthouse accessibility audit score is at least 90%
 * The application is fully tabbable 
 
 ✨WOW✨ can look like: 
+
 * Design is responsive across small, medium and large breakpoints
 * Special consideration was made around accessibility
 </section>
 
 <section class="answer">
-### Fundamental JavaScript and Style / Fetch
+### Fundamental JavaScript and Style / Fetch Competency Examples
 
 * Code is divided into logical components each with a clean, single responsibility
 * Array prototype methods are used to iterate instead of for loops
 * All DOM manipulation is held in the scripts.js file. No DOM manipulation occurs outside of this file.
 * Variables and functions are consistently and appropriately named
 * Code leverages JavaScript's truthy/falsey principles
-* Demonstrates efforts towards making functions pure when possible. Note: Purity is not possible for every function in a FE application. Strive for it only when it makes sense.*
-* Application implements Fetch and updates DOME based on the results of that Fetch. 
+* Demonstrates efforts towards making functions pure when possible. **Note: Purity is not possible for every function in a FE application. Strive for it only when it makes sense.**
+* Implements GET and POST Fetch requests
+* When utilizing Fetch, the DOM is updated based on the results of that Fetch
 * Most errors are handled and messages are displayed to a user when an error occurs
 
 ✨WOW✨ can look like: 
+
 * All data manipulation is cleanly separated from rendering code. 
+* Code has clearly been refactored; functions are DRY and adhere to the Single Responsibility Principle. 
 * All errors are handled and messages are displayed to a user when an error occurs
 </section>
 
@@ -262,6 +268,7 @@ For example: For example: If a user searches for a room, but none are available 
 * There are no failing/pending tests upon submission 
 
 ✨WOW✨ can look like: 
+
 * All scenarios/outcomes/paths are tested for functions, including happy and sad paths.
 * Application has a robust and thorough test suite that covers all functions that do not update the dom.
 </section>

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -225,8 +225,8 @@ For the rubric sections below, you will be scored as Wow, Yes or Not Yet dependi
 <section class="answer">
 ### Functional Expectations
 
-- Wow: Application fulfills all requirements as well as an extension.
-- Yes: Application fulfills all requirements of iterations 1-3 without bugs. **Note: Must be completed in order to pass**
+- Wow: Application fulfills all requirements as well as Iteration 5.
+- Yes: Application fulfills all requirements of iterations 1-4 without bugs. **Note: Must be completed in order to pass**
 - Not Yet: Application crashes or has missing functionality or bugs.
 </section>
 

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -234,6 +234,7 @@ For the rubric sections below, you will be scored as Wow, Yes or Not Yet dependi
 * Helpful messaging is displayed to prevent user confusion. For example: For example: If a user searches for a room, but none are available then a message is displayed to indicate that the search worked, nothing is broken, there just aren't any matching rooms available.
 * The Lighthouse audit tool was used to improve accessibility.
 * The application is fully tabbable 
+* Utilizes ARIA attributes on interactive elements when **no other tool** allows for accessible content
 * Wow option: design is responsive across small, medium and large breakpoints
 </section>
 

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -16,7 +16,6 @@ For this project, you will be building a hotel management tool for hotel custome
 - Make network requests to retrieve data
 - Implement a robust testing suite using TDD
 - Write DRY, reusable code that follows SRP (Single Responsibility Principle)
-- Collaborate productively and professionally as a team. Ensure all team members are able to be heard and contribute throughout the project
 
 
 ## Timeline

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -218,6 +218,8 @@ For this project, an average of 0.5 is considered a yes - a passing project that
 
 For the rubric sections below, you will be scored as Wow, Yes or Not Yet depending on whether you have demonstrated competency in that area. Each section lists examples of what types of things we may be looking for as demonstrations of competency. Just as there are many ways to approach code, there are many many ways to demonstate competency. The following examples are not checklists to complete! There are just some examples.
 
+While M2 rubrics do not have a separate section for WOWs like in M1, there are a few WOW examples noted throughout.  In addition to these WOW bullets, you can strive for a WOW by demonstrating not just competency, but excellence and thoroughness across the rubric sections. 
+
 <section class="answer">
 ### Functional Expectations
 

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -233,7 +233,8 @@ For the rubric sections below, you will be scored as Wow, Yes or Not Yet dependi
 * UI/UX is intuitive and easy to read/use
 * Helpful messaging is displayed to prevent user confusion. For example: For example: If a user searches for a room, but none are available then a message is displayed to indicate that the search worked, nothing is broken, there just aren't any matching rooms available.
 * The Lighthouse audit tool was used to improve accessibility.
-* The application is fully tabbable 
+* Users who only use keyboards can still navigate this application
+* Users who use a screen reader can still navigate this application
 * Utilizes ARIA attributes on interactive elements when **no other tool** allows for accessible content
 * Wow option: design is responsive across small, medium and large breakpoints
 </section>

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -232,13 +232,9 @@ For the rubric sections below, you will be scored as Wow, Yes or Not Yet dependi
 * The application can stand on its own to be used by an instructor without guidance from the developer
 * UI/UX is intuitive and easy to read/use
 * Helpful messaging is displayed to prevent user confusion. For example: For example: If a user searches for a room, but none are available then a message is displayed to indicate that the search worked, nothing is broken, there just aren't any matching rooms available.
-* The Lighthouse accessibility audit score is at least 90%
+* The Lighthouse audit tool was used to improve accessibility.
 * The application is fully tabbable 
-
-✨WOW✨ can look like: 
-
-* Design is responsive across small, medium and large breakpoints
-* Special consideration was made around accessibility
+* Wow option: design is responsive across small, medium and large breakpoints
 </section>
 
 <section class="answer">
@@ -246,38 +242,30 @@ For the rubric sections below, you will be scored as Wow, Yes or Not Yet dependi
 
 * Code is divided into logical components each with a clean, single responsibility
 * Array prototype methods are used to iterate instead of for loops
-* All DOM manipulation is held in the scripts.js file. No DOM manipulation occurs outside of this file.
+* Project is organized to separate concerns (Ask yourself - where should my DOM manipulation live?)
 * Variables and functions are consistently and appropriately named
 * Code leverages JavaScript's truthy/falsey principles
 * Demonstrates efforts towards making functions pure when possible. **Note: Purity is not possible for every function in a FE application. Strive for it only when it makes sense.**
 * Implements GET and POST Fetch requests
 * When utilizing Fetch, the DOM is updated based on the results of that Fetch
-* Most errors are handled and messages are displayed to a user when an error occurs
+* Errors are handled and messages are displayed to a user when an error occurs
+* Wow option: Effectively implements one or more closure throughout project.
 
-✨WOW✨ can look like: 
-
-* All data manipulation is cleanly separated from rendering code. 
-* Code has clearly been refactored; functions are DRY and adhere to the Single Responsibility Principle. 
-* All errors are handled and messages are displayed to a user when an error occurs
-* Effectively implements one or more closure throughout project.
 </section>
 
 <section class="answer">
 ### Testing
 
-* Tests cover most features and test for happy paths
-* Test suite is organized.
-* Each function is tested in its own it block.
+* Application has a robust and thorough test suite that covers functions that do not update the dom.
+* Testing includes happy and sad paths
+* Test suite is organized - a new developer could easily identify what function is causing a test to fail
 * Each path is tested in its own it block.
 * Rather than using the production data, small sample data is stored in its own file and used for testing.
 * Sample data has been crafted to create the scenarios needed for thorough testing.
 * beforeEach hook is used to DRY up test files
+* Tests are DRY (Ask yourself - what tools can I use to limit repetitive code?)
 * There are no failing/pending tests upon submission 
 
-✨WOW✨ can look like: 
-
-* All scenarios/outcomes/paths are tested for functions, including happy and sad paths.
-* Application has a robust and thorough test suite that covers all functions that do not update the dom.
 </section>
 
 # Evaluation

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -260,7 +260,6 @@ For the rubric sections below, you will be scored as Wow, Yes or Not Yet dependi
 * Application has a robust and thorough test suite that covers functions that do not update the dom.
 * Testing includes happy and sad paths
 * Test suite is organized - a new developer could easily identify what function is causing a test to fail
-* Each path is tested in its own it block.
 * Rather than using the production data, small sample data is stored in its own file and used for testing.
 * Sample data has been crafted to create the scenarios needed for thorough testing.
 * Tests are DRY (Ask yourself - what tools can I use to limit repetitive code?)

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -263,7 +263,6 @@ For the rubric sections below, you will be scored as Wow, Yes or Not Yet dependi
 * Each path is tested in its own it block.
 * Rather than using the production data, small sample data is stored in its own file and used for testing.
 * Sample data has been crafted to create the scenarios needed for thorough testing.
-* beforeEach hook is used to DRY up test files
 * Tests are DRY (Ask yourself - what tools can I use to limit repetitive code?)
 * There are no failing/pending tests upon submission 
 

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -209,13 +209,16 @@ ARIA attributes should be utilized for any UI elements that are not understood b
 
 For the rubric sections below, you will be scored as Wow, Yes or Not Yet depending on whether you have demonstrated competency in that area. Each section lists examples of what types of things we may be looking for as demonstrations of competency. Just as there are many ways to approach code, there are many many ways to demonstate competency. There are just some examples.
 
+<section class="answer">
+### Functional Expectations
 
-## Functional Expectations
-Wow: Application fulfills all requirements as well as an extension.
-Yes: Application fulfills all requirements of iterations 1-3 without bugs. **Notes: Must be completed in order to pass**
-Not Yet: Application crashes or has missing functionality or bugs.
+- Wow: Application fulfills all requirements as well as an extension.
+- Yes: Application fulfills all requirements of iterations 1-3 without bugs. **Note: Must be completed in order to pass**
+- Not Yet: Application crashes or has missing functionality or bugs.
+</section>
 
-## UI/UX & Accessibility
+<section class="answer">
+### UI/UX & Accessibility
 
 * The application can stand on its own to be used by an instructor without guidance from a developer on the team.
 UI/UX is intuitive and easy to read/use
@@ -227,8 +230,10 @@ For example: For example: If a user searches for a room, but none are available 
 ✨WOW✨ can look like: 
 * Design is responsive across small, medium and large breakpoints
 * Special consideration was made around accessibility
+</section>
 
-## Fundamental JavaScript and Style / Fetch
+<section class="answer">
+### Fundamental JavaScript and Style / Fetch
 
 * Code is divided into logical components each with a clean, single responsibility
 * Array prototype methods are used to iterate instead of for loops
@@ -242,13 +247,10 @@ For example: For example: If a user searches for a room, but none are available 
 ✨WOW✨ can look like: 
 * All data manipulation is cleanly separated from rendering code. 
 * All errors are handled and messages are displayed to a user when an error occurs
+</section>
 
-## Testing
-
-* 4: Application covers all aspects of the application including various flows and covers both happy/sad paths. Tests must be passing to be considered.
-* 3: Application is well tested but fails to cover some features and only tests for happy paths.  Tests must be passing to be considered.
-* 2: Project has sporadic use of tests at multiple levels. The application contains numerous holes in testing and/or many features are untested.  Tests must be passing to be considered.
-* 1: There is little or no evidence of testing in the application.
+<section class="answer">
+### Testing
 
 * Tests cover most features and test for happy paths
 * Test suite is organized.
@@ -262,6 +264,7 @@ For example: For example: If a user searches for a room, but none are available 
 ✨WOW✨ can look like: 
 * All scenarios/outcomes/paths are tested for functions, including happy and sad paths.
 * Application has a robust and thorough test suite that covers all functions that do not update the dom.
+</section>
 
 ## Collaboration and Professionalism
 

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -229,7 +229,7 @@ For the rubric sections below, you will be scored as Wow, Yes or Not Yet dependi
 <section class="answer">
 ### UI/UX & Accessibility
 
-* The application can stand on its own to be used by an instructor without guidance from a developer on the team.
+* The application can stand on its own to be used by an instructor without guidance from the developer
 * UI/UX is intuitive and easy to read/use
 * Helpful messaging is displayed to prevent user confusion. For example: For example: If a user searches for a room, but none are available then a message is displayed to indicate that the search worked, nothing is broken, there just aren't any matching rooms available.
 * The Lighthouse accessibility audit score is at least 90%


### PR DESCRIPTION
This PR addressed issue #618 

**Changes Requested in Issue**
- [x] The current project outlines the use of classes to build the project
- [x] The started repo similarly pushes students to build out classes **Please see [this PR](https://github.com/turingschool-examples/webpack-starter-kit/pull/228) to address this bullet point**
- [x] The push to use classes needs to be removed to instead push students to functions
- [ ] Additionally, the project currently demands the use of webpack. This could be replaced with Parcel, a modern alternative build tool that is less configuration heavy. **See question in question section below**
- [x] Update rubrics to use the Yes, Not Yet, Wow scale that was piloted on M1 projects. Use M1 final projects as a guide for consistency.

**Changes Made:**
- added webpack to the technologies list
- updated objectives to reflect functional paradigm expectations
- removed redundant timeline and date information
- moved workflow requirements above the iterations because it's more of a planning topic. 
- made a note to connect their previously more scaffolded projects in the "Iterations Section" because they won't receive dictated functions to create for this project. (This is how it originally was, it just didn't explain it) See the more scaffolded version [here](https://github.com/turingschool/front-end-curriculum/pull/646)
- updated various sections including collaboration expectations and testing sections to align with [this What's Cookin draft](https://github.com/turingschool/front-end-curriculum/pull/646)
- styled the Rubric section to match up more with the Mod 1 rubric. [example](https://frontend.turing.edu/projects/module-1/rock-paper-scissors-solo-v2.html)
- updated rubric sections to reflect functional paradigm expectations

**Motivations**
- seems good to have the Mod2 rubrics match the Mod1 rubrics
- need functional style information instead of OOP style information

**Questions**
- Do we like the style of the rubric (with the little, clickable drop downs?)? I'm happy to change it however. 
- Do we want to tell the students what a passing score is? Seems like a nice thing to do, especially since instructors jump around so much. (for example, see [this project](https://frontend.turing.edu/projects/module-1/rock-paper-scissors-solo-v2.html))
- Does anybody have an opinion on the Parcel vs Webpack discussion? See [this thread](https://turingschool.slack.com/archives/C04M84TG3U4/p1677874882067189).
- Does anybody have an opinion on what kinds of files students are expected to use in this project? Right now, the webpack starter kit is set up to let students create the files they want. We aren't dictating it to them... Personally, I like this because they're going to have to be able to make these decisions to be successful in React. See [this thread](https://turingschool.slack.com/archives/C04M84TG3U4/p1679418003094029). 

Completed #618