### PR TITLE
Stretch rubric updates

### DIFF
--- a/projects/module-3/showcase.md
+++ b/projects/module-3/showcase.md
@@ -186,7 +186,6 @@ While M3 rubrics do not have a separate section for WOWs like in M1, there are a
 <section class="answer">
 ### React Architecture:
 
-💫ON TRACK💫 can look like:
 * A consistent, modular file structure is used
 * A clear understanding of stateful components vs stateless components is demonstrated
 * Only the data that a child component _needs_ is passed down as props

--- a/projects/module-3/stretch.md
+++ b/projects/module-3/stretch.md
@@ -248,25 +248,28 @@ Evals are
 * Two interview questions - one technical (about your stretch tech) and one behavioral (you get to choose the "theme", but not the specific question)
 * You will be expected to send your interviewer your resume (updated with the stretch project) prior to the interview via slack
 
+## Minimum Collaboration and Professionalism Expectations
+
+* Team holds daily standups throughout project.
+* Commits are atomic and frequent, effectively documenting the evolution/progression of the application. There is no more than a 10% disparity in project contributions between teammates.
+* A project board is utilized (and updated throughout the project) with Github issues and labels.
+* Team uses branches, PRs and thorough code reviews to add new code to the main branch.
+* The README is formatted well and at a minimum contains:
+  * Overview of project and goals
+  * Overview of technologies used, challenges, wins, and any other reflections
+  * Screenshots/gifs of your app
+  * List of contributors
+* **Team collaborates effectively to accomplish the shared goal.  Team productively and professionally works through challenges and conflicts to ensure all team members are able to be heard and contribute throughout the project.**  
+  * Instructors are available to offer support and guidance but conversations around what *is* and what *is not* working are expected to be led by the team members themselves.
+
 ## Rubric
 
 There will be no written feedback for this project, but each and every one of you is capable of self-assessing whether or not your project is proficient. Mentors and Rocks are also a valuable resource here. **A proficient project would include the following:**  
 
 <section class="answer">
-### Minimum Collaboration and Professionalism Expectations
+### Professionalism 
 
-On track can look like:
-* Project is deployed
-* README concisely communicates the team's individual and joint learning goals, the evolution of the project, and team member reflections while using good formatting to enhance readability
-* README links to all user GitHub profiles and any applicable repos & deployed sites
-* Setup instructions for any and all repos are thorough and verbose enough that even non-technical people (like recruiters) could follow them
-* Git commits are atomic, with concise and precise descriptions of the change made
-* PRs have full, consistent descriptions
-* Team members conduct consistent code reviews of PRs
-* Evolution of the project (decisions made, etc) is documented in the git history and PRs
-* When the project is run locally, the terminal shows no errors and no warnings.
-* The Team collaborates effectively to accomplish the shared goal. The Team productively and professionally works through challenges and conflicts to ensure all team members are able to be heard and contribute throughout the project.
-  * Instructors are available to offer support and guidance but conversations around what is and what is not working are expected to be led by the team members themselves.
+Professionalism is a baseline expectation - you can those expectations above in the Minimum Collaboration and Professionalism Expectations Section. If you want to go further, check below for some ideas.
 
 WOW can look like:
 * Mapping out extensions in your project board beyond your MVP


### PR DESCRIPTION
This PR addressed issue 632 which is already closed. I just wanted to make a change to this rubric to better align it with the changes I later made to the showcase project

### Changes Requested in Issue:

- [x] Move the minimum collaboration and professionalism expectations out of the rubric to better indicate that they are not scored, but still are expected

### Changes Made:

- [x] All of the above

### Questions:
The rubric feels like it might be missing a section to evaluate wether or not the project meets the following requirements - do we need to add that or is listing those items as "required" enough? Was there previously a "spec adherance" section to cover this?
- Meet the specs listed below under “MVP”
- Use at least one external API
- Implement one of the “Stretch Technologies” listed below.
- Be deployed 
- Be a featured project on your resume (Your resume must meet all requirements listed in [this document](https://careerdev.turing.edu/resources/resume_resources).)
