### PR TITLE
Update MVC lesson example, add MDN link to MVC

### DIFF
--- a/lessons/module-3/mvc.md
+++ b/lessons/module-3/mvc.md
@@ -41,7 +41,7 @@ categories; the model, the view, and the controller. In this pattern, each
 component has its own specific responsibility. While implemented slightly
 differently in various frameworks, the general pattern is one of the most
 frequently used industry standards for creating scalable and extensible
-software.
+software. 
 
 The **Model** is focused solely on the data, and data related logic of the
 application. This could be business data for the application, or data that is
@@ -63,6 +63,8 @@ for this pattern, you will find it all over the place.
 ![MVC interactions](https://www.tutorialspoint.com/sencha_touch/images/mvc.jpg
 "Data flow in MVC")
 
+Take a look at [the docs on MDN](https://developer.mozilla.org/en-US/docs/Glossary/MVC) if you'd like to see it explained in another way.
+
 ### Ok, by why would I ever use it?
 
 You've already been using it! Let's consider a super simple example:
@@ -70,28 +72,22 @@ You've already been using it! Let's consider a super simple example:
 ```js
 import React, { Component } from 'react';
 
-class App extends Component {
-  constructor() {
-    super()
-    this.state = {
-      count: 0,
-    }
+function App() {
+  const [count, setCount] = useSate(0);
+
+
+   handleCounter = (event) => {
+    const increment = event.target.name === '+' ? 1 : -1;
+    setCount(count + increment)
   }
 
-  handleCounter = (event) => {
-    const increment = event.target.name === '+' ? 1 : -1
-    this.setState({count: this.state.count + increment})
-  }
-
-  render() {
-    return (
-      <div className="App">
-        <h1>{this.state.count}</h1>
-        <button onClick={this.handleCounter} name="-">-</button>
-        <button onClick={this.handleCounter} name="+">+</button>
-      </div>
-    );
-  }
+  return (
+    <div className="App">
+      <h1>{count}</h1>
+      <button onClick={(e) => handleCounter(e)} name="-">-</ button>
+      <button onClick={(e) => handleCounter(e)} name="+">+</button>
+    </div>
+  )
 }
 
 export default App;

--- a/lessons/module-3/mvc.md
+++ b/lessons/module-3/mvc.md
@@ -70,10 +70,10 @@ Take a look at [the docs on MDN](https://developer.mozilla.org/en-US/docs/Glossa
 You've already been using it! Let's consider a super simple example:
 
 ```js
-import React, { Component } from 'react';
+import React from 'react';
 
 function App() {
-  const [count, setCount] = useSate(0);
+  const [count, setCount] = useState(0);
 
 
    handleCounter = (event) => {
@@ -141,12 +141,12 @@ few MVP (Model View Presenter) frameworks that you may come across are:
 
 ### Wrapping it up
 
-In small groups draw out the MVC of your most recent application. How does Redux
-play into this? Work on this for 10 minutes, then we'll reconvene.
+In small groups draw out the MVC of your most recent application. Work on this for 10 minutes, then we'll reconvene.
 
 ## References
 
-[MVC
+- [MVC
 Architecture](https://developer.mozilla.org/en-US/docs/Glossary/MVC)
-[Understanding
+
+- [Understanding
 MVC](https://blog.codinghorror.com/understanding-model-view-controller/)  


### PR DESCRIPTION
This PR addressed issue #710 

## Summary of changes needed: 
- [x] The current lesson uses a class based component to describe the MVC pattern
- [x] This example needs to be updated to be a functional component
- [x] Any language in the lesson that is referring to that class based component may also need to be updated
- [x] The lesson should include a link to the MVC pattern architecture page on MDN

### Changes Made:

- [x] All of the above

### Questions
- Please review my react code - I was feeling a bit rusty!
- No other specific considerations
