### PR TITLE
729 - final project a11y update

### DIFF
--- a/projects/module-2/fitlit-part-one-agile.md
+++ b/projects/module-2/fitlit-part-one-agile.md
@@ -290,7 +290,7 @@ For the rubric sections below, you will be scored as **Wow**, **Yes** or **Not Y
 💫ON TRACK💫 can look like:
 - Application fulfills all requirements of iterations 1-5 without bugs.
 
-✨WOW✨ can look like:
+✨**WOW**✨ can look like:
 - Application fulfills all requirements *as well as* an extension.
 
 </section>
@@ -306,7 +306,7 @@ For the rubric sections below, you will be scored as **Wow**, **Yes** or **Not Y
 - Code leverages JavaScript's truthy/falsey principles.
 - Demonstrates efforts towards making functions pure when possible. *Note: Purity is not possible for every function in a FE application. Strive for it only when it makes sense.*
 
-✨WOW✨ can look like:
+✨**WOW**✨ can look like:
 - Effectively implements one or more closure throughout project.  *Note: See Closures lesson on M2 lesson page as a resource.*
 </section>
 
@@ -335,7 +335,7 @@ For the rubric sections below, you will be scored as **Wow**, **Yes** or **Not Y
 - Helpful messaging is displayed to prevent user confusion.
   - ***For example:** If a user hasn't been active for 7 days, a message is displayed saying there isn't enough data to show their weekly report for each data point.*
 
-✨WOW✨ can look like:
+✨**WOW**✨ can look like:
 - Design is responsive across small, medium and large breakpoints.
 </section>
 

--- a/projects/module-2/fitlit-part-two-agile.md
+++ b/projects/module-2/fitlit-part-two-agile.md
@@ -234,7 +234,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 
 <section class="answer">
 ### Functional Expectations
-* Wow: Application fulfills all iteration requirements, without bugs, and the user experience is intuitive and consistent.
+* **Wow**: Application fulfills all iteration requirements, without bugs, and the user experience is intuitive and consistent.
 * Yes: Application fulfills all iteration requirements, including implementing feedback from Part 1 and feedback from the usability test.
 * Not Yet: Application crashes or has missing functionality or bugs.
 </section>
@@ -257,7 +257,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 - Users can have a seamless experience using only a keyboard to navigate the application (no mouse).
 - Users who have color-blindness can utilize this application without issue.
 - ARIA attributes are used on interactive elements if needed - and *only* if needed.
-* Wow option: design is responsive across small, medium and large breakpoints
+- **Wow option**: design is responsive across small, medium and large breakpoints
 </section>
 
 <section class="answer">
@@ -269,7 +269,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 - `fetch` is effectively implemented for GET and POST
 - DOM is updated based on the results of network requests
 - Demonstrates efforts towards making functions pure when possible. *Note: Purity is not possible for every function in a FE application. Strive for it only when it makes sense.*
-- WOW option: Effectively implements one or more closure throughout project.  *Note: See Closures lesson on M2 lesson page as a resource.*
+- **WOW option**: Effectively implements one or more closure throughout project.  *Note: See Closures lesson on M2 lesson page as a resource.*
 </section>
 
 ### Collaboration and Professionalism 

--- a/projects/module-2/flash-cards.md
+++ b/projects/module-2/flash-cards.md
@@ -224,7 +224,7 @@ For the rubric sections below, you will be scored as **Wow**, **Yes** or **Not Y
 
 <section class="answer">
 ### Functional Expectations
-* Wow: Application fulfills all requirements *as well as* an extension from iteration 4.
+* **Wow**: Application fulfills all requirements *as well as* an extension from iteration 4.
 * Yes: Application fulfills all requirements of iterations 1-3 without bugs.
 * Not Yet: Application crashes (game is not playable) or has missing functionality or bugs.
 </section>
@@ -239,7 +239,7 @@ On track looks like:
 - Code leverages JavaScript's truthy/falsey principles
 - Demonstrates efforts towards making functions pure when possible. *Note: Purity is not possible for every function in a FE application. Strive for it only when it makes sense.*
 
-WOW Option: Effectively implements one or more closures throughout project.  *Note: See Closures lesson on the Module 2 lessons page as a resource.*
+**WOW Option**: Effectively implements one or more closures throughout project.  *Note: See Closures lesson on the Module 2 lessons page as a resource.*
 </section>
 
 <section class="answer">
@@ -253,7 +253,7 @@ On track looks like:
   - Sample data has been crafted to create the scenarios needed for thorough testing.
 - There are no failing/pending tests upon submission
 
-WOW Option: mocha's `beforeEach` hook is used to DRY up test files
+**WOW Option**: mocha's `beforeEach` hook is used to DRY up test files
 </section>
 
 Project is due at **9PM on Thursday of Week 1**.

--- a/projects/module-2/whats-cookin-part-one.md
+++ b/projects/module-2/whats-cookin-part-one.md
@@ -255,7 +255,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 
 <section class="answer">
 ### Functional Expectations
-* Wow: Application fulfills all requirements *as well as* an extension.
+* **Wow**: Application fulfills all requirements *as well as* an extension.
 * Yes: Application fulfills all requirements of iterations 1-3 without bugs.
 * Not Yet: Application crashes or has missing functionality or bugs.
 </section>
@@ -268,7 +268,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 - Variables and functions are consistently and appropriately named
 - Code leverages JavaScript's truthy/falsey principles
 - Demonstrates efforts towards making functions pure when possible. *Note: Purity is not possible for every function in a FE application. Strive for it only when it makes sense.*
-- WOW option: Effectively implements one or more closure throughout project.  *Note: See Closures lesson on M2 lesson page as a resource.*
+- **WOW option**: Effectively implements one or more closure throughout project.  *Note: See Closures lesson on M2 lesson page as a resource.*
 </section>
 
 <section class="answer">
@@ -291,7 +291,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 - UI/UX is intuitive and easy to read/use
 - Helpful messaging is displayed to prevent user confusion
   - For example: If a user searches for a recipe and finds no matching results, a message is displayed to indicated that the search worked, nothing is broken, there just aren't any matching recipes found.
-- WOW option: Design is responsive across small, medium and large breakpoints.
+- **WOW option**: Design is responsive across small, medium and large breakpoints.
 </section>
 
 ---

--- a/projects/module-2/whats-cookin-part-two-agile.md
+++ b/projects/module-2/whats-cookin-part-two-agile.md
@@ -178,7 +178,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 
 <section class="answer">
 ### Functional Expectations
-* Wow: Application fulfills all iteration requirements, without bugs, and the user experience is intuitive and consistent.
+* **Wow**: Application fulfills all iteration requirements, without bugs, and the user experience is intuitive and consistent.
 * Yes: Application fulfills all iteration requirements, including implementing feedback from Part 1 and feedback from the usability test.
 * Not Yet: Application crashes or has missing functionality or bugs.
 </section>
@@ -201,7 +201,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 - Users can have a seamless experience using only a keyboard to navigate the application (no mouse).
 - Users who have color-blindness can utilize this application without issue.
 - ARIA attributes are used on interactive elements if needed - and *only* if needed.
-* Wow option: design is responsive across small, medium and large breakpoints
+- **Wow option**: design is responsive across small, medium and large breakpoints
 </section>
 
 <section class="answer">
@@ -213,7 +213,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 - `fetch` is effectively implemented for GET and POST
 - DOM is updated based on the results of network requests
 - Demonstrates efforts towards making functions pure when possible. *Note: Purity is not possible for every function in a FE application. Strive for it only when it makes sense.*
-- WOW option: Effectively implements one or more closure throughout project.  *Note: See Closures lesson on M2 lesson page as a resource.*
+- **WOW option**: Effectively implements one or more closure throughout project.  *Note: See Closures lesson on M2 lesson page as a resource.*
 </section>
 
 ### Collaboration and Professionalism 

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -111,10 +111,10 @@ Don't get too caught up with polishing your dashboard too early. You'll want to 
 
 ### 3. Accessibility
 
-* Create a branch for accessibility.  
-* Use this branch to make your dashboard as accessible as possible.  
-* Push this branch up to GH.  You can merge the changes into main but do not delete this branch.  
-  * This branch should not have a login page so that during the live eval, we can run the Lighthouse audit and check tabbability of your dashboard (without the login page).  
+* You must be able to tab through your app and use it without a mouse 
+* Your app must still be usable when tested with a colorblind extension
+* You must score as close to 100% as possible with the “Lighthouse Accessibility Audit”. Be prepared to explain any accessibility audits your application is failing.
+* Your HTML must be written semantically and should use ARIA tags (ONLY if needed / appropriate)
 
 ### 4. Login
 

--- a/projects/overlook.md
+++ b/projects/overlook.md
@@ -223,7 +223,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 <section class="answer">
 ### Functional Expectations
 
-- Wow: Application fulfills all requirements as well as Iteration 5.
+- **Wow**: Application fulfills all requirements as well as Iteration 5.
 - Yes: Application fulfills all requirements of iterations 1-4 without bugs. **Note: Must be completed in order to pass**
 - Not Yet: Application crashes or has missing functionality or bugs.
 </section>
@@ -238,7 +238,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 * Users who only use keyboards can still navigate this application
 * Users who use a screen reader can still navigate this application
 * Utilizes ARIA attributes on interactive elements when **no other tool** allows for accessible content
-* Wow option: design is responsive across small, medium and large breakpoints
+* **Wow option**: design is responsive across small, medium and large breakpoints
 </section>
 
 <section class="answer">
@@ -253,7 +253,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 * Implements GET and POST Fetch requests
 * When utilizing Fetch, the DOM is updated based on the results of that Fetch
 * Errors are handled and messages are displayed to a user when an error occurs
-* Wow option: Effectively implements one or more closure throughout project.
+* **Wow option**: Effectively implements one or more closure throughout project.
 
 </section>
 

--- a/projects/travel-tracker.md
+++ b/projects/travel-tracker.md
@@ -103,10 +103,10 @@ Don't get too caught up with polishing your dashboard too early. You'll want to 
 
 ### 3. Accessibility
 
-* Create a branch for accessibility.  
-* Use this branch to make your dashboard as accessible as possible.  
-* Push this branch up to GH.  You can merge the changes into main but do not delete this branch.  
-  * This branch should not have a login page so that during the live eval, we can run the Lighthouse audit and check tabbability of your dashboard (without the login page).  
+* You must be able to tab through your app and use it without a mouse 
+* Your app must still be usable when tested with a colorblind extension
+* You must score as close to 100% as possible with the “Lighthouse Accessibility Audit”. Be prepared to explain any accessibility audits your application is failing.
+* Your HTML must be written semantically and should use ARIA tags (ONLY if needed / appropriate)
 
 ### 4. Login
 

--- a/projects/travel-tracker.md
+++ b/projects/travel-tracker.md
@@ -226,7 +226,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 <section class="answer">
 ### Functional Expectations
 
-- Wow: Application fulfills all requirements as well as Iteration 5 or an extension.
+- **Wow**: Application fulfills all requirements as well as Iteration 5 or an extension.
 - Yes: Application fulfills all requirements of iterations 1-4 without bugs. **Note: Must be completed in order to pass**
 - Not Yet: Application crashes or has missing functionality or bugs.
 </section>
@@ -241,7 +241,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 * Users who only use keyboards can still navigate this application
 * Users who use a screen reader can still navigate this application
 * Utilizes ARIA attributes on interactive elements when no other tool allows for accessible content
-* Wow option: design is responsive across small, medium and large breakpoints
+* **Wow option**: design is responsive across small, medium and large breakpoints
 </section>
 
 <section class="answer">
@@ -256,7 +256,7 @@ While M2 rubrics do not have a separate section for WOWs like in M1, there are a
 * Implements GET and POST Fetch requests
 * When utilizing Fetch, the DOM is updated based on the results of that Fetch
 * Errors are handled and messages are displayed to a user when an error occurs
-* Wow option: Effectively implements one or more closure throughout project.
+* **Wow option**: Effectively implements one or more closure throughout project.
 </section>
 
 <section class="answer">


### PR DESCRIPTION
Description of changes made

- Updates a11y section on rubrics - students will not need to make a branch b/c we are shifting to snapshot testing
- Makes bold WOW sections on rubrics
- Closes https://github.com/turingschool/front-end-curriculum/issues/729

Motivation for any changes

- Removes some barriers and confusion around final projects
- Improves readability on rubrics 

Questions that you have for a reviewer

- How does verbiage sound in final projects (overlook, travel tracker)