### PR TITLE
722 fix broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@ title: Home
   <a class="btn btn-dark" href="/lessons">Lessons</a>
   <a class="btn btn-dark" href="/projects">Projects</a>
   <a class="btn btn-dark" href="https://careerdev.turing.edu">Professional Development</a>
-  <a class="btn btn-dark" target="_blank" rel="noopener" href="https://community.turing.edu/">Community</a>
   <a class="btn btn-dark" href="/mental_health">Mental Health Resources</a>
 </section>
 

--- a/lessons/independent-study/all-the-databases.md
+++ b/lessons/independent-study/all-the-databases.md
@@ -197,7 +197,7 @@ Map and Reduce are commonly used together when querying a document store DB. You
 
 ### No(t)SQL
 
-[A decent cheat sheet for common things](https://blog.codecentric.de/files/2012/12/MongoDB-CheatSheet-v1_0.pdf)
+[A decent cheat sheet for common things](https://github.com/fossfreaks/web-dev-cheat-sheets/blob/master/MongoDB-CheatSheet-v1_0.pdf)
 
 #### Insert
 

--- a/lessons/independent-study/all-the-databases.md
+++ b/lessons/independent-study/all-the-databases.md
@@ -120,24 +120,24 @@ This will return us the `title`, `description` and `author` of each post for the
 
 ### Exercises
 
-- Here's a sandbox: <http://www.dofactory.com/sql/sandbox>
-  - List the first and last name of all the customers
+- Here's a sandbox: <https://www.w3schools.com/sql/trysql.asp?filename=trysql_asc>
+  - List the CustomerName of all the customers
   - List all fields for customers from Germany
   - Insert a new customer record for yourself. What's your id?
-  - List all the orders from Maria Anders (hint: you don't need a join yet)
-  - Return the sum total amount from all of Maria Anders' orders
+  - List all the orders from Hanari Carnes (hint: you don't need a join yet)
+  - Return the sum total amount from all of Hanari Carnes' orders
   - Return the number of customers from each country
 
 - Some Backend Mod 2 lessons:
   - http://backend.turing.edu/module2/lessons/visualising_and_implementing_database_relationships
   - https://github.com/turingschool/lesson_plans/blob/master/ruby_02-web_applications_with_ruby/outlines/introduction_to_sql.markdown
 - A Backend Mod 3 lesson: <https://github.com/turingschool/lesson_plans/blob/master/ruby_03-professional_rails_applications/intermediate_sql.md>
-- [A nifty sandbox](http://www.dofactory.com/sql/sandbox). Try these things:
+- [A nifty sandbox](https://www.w3schools.com/sql/trysql.asp?filename=trysql_asc). Try these things:
   - List the first and last name of all the customers
   - List all fields for customers from Germany
   - Insert a new customer record for yourself. What's your id?
-  - List all the orders from Maria Anders (hint: you don't need a join yet)
-  - Return the sum total amount from all of Maria Anders' orders
+  - List all the orders from Hanari Carnes (hint: you don't need a join yet)
+  - Return the sum total amount from all of Hanari Carnes' orders
   - Return the number of customers from each country
   - Return the concatenated first and last name of all customers
 - Creating a hybrid document/relational database: <http://rob.conery.io/2015/03/01/document-storage-gymnastics-in-postgres/>

--- a/lessons/independent-study/all-the-databases.md
+++ b/lessons/independent-study/all-the-databases.md
@@ -271,7 +271,7 @@ Nodes and Edges have properties. There is no requirement that properties are con
 
 ### Getting started
 
-You need to install the JDK before you can install Neo4j. Type `javac -version` to see if you have it. If you don't you'll probably be prompted to install it. You can try that. I haven't. If you're already a user of [`brew cask`](https://caskroom.github.io/), just `brew cask install java`. Otherwise, [download from here](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+You need to install the JDK before you can install Neo4j. Type `javac -version` to see if you have it. If you don't you'll probably be prompted to install it. You can try that. I haven't. If you're already a user of [`brew cask`](https://github.com/Homebrew/homebrew-cask), just `brew install java`. Otherwise, [download from here](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 
 Then you can `brew install neo4j` and follow the instructions to start the server.
 

--- a/lessons/independent-study/css-performance-and-organization.md
+++ b/lessons/independent-study/css-performance-and-organization.md
@@ -267,6 +267,6 @@ By grouping our styles together by content (or layout) type, we reenforce that w
 
 [CSS Tricks: Efficiently Rendering CSS](https://css-tricks.com/efficiently-rendering-css/)
 
-[Writing efficient CSS](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Writing_efficient_CSS)
+[Writing efficient CSS](https://developer.mozilla.org/en-US/docs/Learn/Performance/CSS)
 
 [Jonathan Snook's guide, Scaleable and Modular Architecture for CSS](https://smacss.com/)

--- a/lessons/independent-study/up-git-creek.md
+++ b/lessons/independent-study/up-git-creek.md
@@ -272,7 +272,6 @@ git help <command>
 ### From novice to Git Greatness, these things will git you there:
 
 - [Try Git](https://try.github.io/levels/1/challenges/1)
-- [Github On Demand](https://github.github.io/on-demand/)
 - [Pro Git](https://progit.org/)
 - [Atlassian Advanced Git](https://www.atlassian.com/git/tutorials/advanced-overview/)
 - [Git Docs](https://git-scm.com/docs)

--- a/lessons/module-1/css-flexbox.md
+++ b/lessons/module-1/css-flexbox.md
@@ -179,6 +179,12 @@ If flex isn't working the way you think it should, check the following things:
 - *Am I sure I'm adding the flex properties to the correct element?* Check the parent-child relationship in the HTML file to be sure that you are adding those properties to the direct parent.
 - *Is the parent element big enough?* Add a border to the parent element. If it is the same width and/or height as the children, you won't be able to move those children as expected.
 
+CSS tends to require a lot of trial and error when you're first learning it. Often, the CSS flow for newbies is something like:
+ - Developer edits their css file and reload their webpage to see if it's what they want.
+ - Developer realizes it's not quite right, so they edit their CSS file again, reload again, on and on and on.
+
+We encourage you to make your CSS changes in your dev tools which will instantly show you the result. You can keep editing the CSS right in your dev tools until it's right, then copy those rules over to your text editor and save yourself all the time on the back and forth.
+
 ## Using Flexbox on Nested Elements
 
 <div class="call-to-action">

--- a/lessons/module-1/css-grid-slides.html
+++ b/lessons/module-1/css-grid-slides.html
@@ -27,7 +27,7 @@ layout: presentation
     <ul>
       <li><a href="http://grid-masterclass.webflow.io" target="_blank">Grid Masterclass </a></li>
       <li><a href="http://piet-mongrid.webflow.io" traget="_blank">Piet Mongrid</a></li>
-      <li><a href="http://marvel-grid.webflow.io/" target="_blank">Marvel Grid</a></li>
+      <li><a href="https://codepen.io/dannievinther/pen/EvVggR" target="_blank">Marvel Grid</a></li>
     </ul>
 </section>
 

--- a/lessons/module-1/css-grid-tutorial.md
+++ b/lessons/module-1/css-grid-tutorial.md
@@ -20,7 +20,7 @@ As you work through this, please keep in mind that there are always _many_ ways 
 
 CSS has always been used to layout web pages, but was never very good at it.
 Flexbox helped out, but it's intended for simpler one-dimensional layouts, not complex two-dimensional ones
-(Flexbox and Grid actually work very well together). Can you imagine building [this](http://marvel-grid.webflow.io/) with Flexbox? Or [this](http://grid-masterclass.webflow.io)?
+(Flexbox and Grid actually work very well together). Can you imagine building [this](https://codepen.io/dannievinther/pen/EvVggR) with Flexbox? Or [this](http://grid-masterclass.webflow.io)?
 
 ## Set Up
 

--- a/lessons/module-1/css-layout.md
+++ b/lessons/module-1/css-layout.md
@@ -19,9 +19,7 @@ Come prepared to class by reading [CSS Specificity + Combinators](https://fronte
 
 ## Warm Up
 
-Checks for understanding and questions from the Pre-work.
-
-<!-- [Instructor Resource](https://docs.google.com/presentation/d/1ZM4pRSnB-pgvXvpCoRjYPt-RmRncYPahvOCibIuS1WU/edit#slide=id.g78e7823268_0_0) -->
+[Instructor Resource](https://docs.google.com/presentation/d/1lKOoG9BPFM1xjUGZNPJXzX6ifnWOm2fCvpCzLbkat5Y/edit?usp=sharing)
 
 ## Display
 

--- a/lessons/module-1/css-layout.md
+++ b/lessons/module-1/css-layout.md
@@ -19,7 +19,9 @@ Come prepared to class by reading [CSS Specificity + Combinators](https://fronte
 
 ## Warm Up
 
-[Instructor Resource](https://docs.google.com/presentation/d/1ZM4pRSnB-pgvXvpCoRjYPt-RmRncYPahvOCibIuS1WU/edit#slide=id.g78e7823268_0_0)
+Checks for understanding and questions from the Pre-work.
+
+<!-- [Instructor Resource](https://docs.google.com/presentation/d/1ZM4pRSnB-pgvXvpCoRjYPt-RmRncYPahvOCibIuS1WU/edit#slide=id.g78e7823268_0_0) -->
 
 ## Display
 

--- a/lessons/module-1/js-event-bubbling-and-delegation.md
+++ b/lessons/module-1/js-event-bubbling-and-delegation.md
@@ -227,4 +227,4 @@ parent.addEventListener('click', function(event) {
 
 <!-- For now, we no longer teach jQuery so commenting this out for the time being. -->
 <!-- - Now that you have some jQuery under your belt - you should know that jQuery has an easy way to do event delegation with the 'on' function. [Check out the docs here](http://api.jquery.com/on/) -->
-- A very detailed piece that describes [event order](https://www.quirksmode.org/js/events_order.html) can be found here
+- A very detailed piece that describes [event order](https://web.archive.org/web/20230527190018/https://www.quirksmode.org/js/events_order.html) can be found here

--- a/lessons/module-1/repeater-hub.md
+++ b/lessons/module-1/repeater-hub.md
@@ -12,7 +12,7 @@ Make sure you are part of the following channels:
 ## Goal Tracking
 Add your name to [this Goals Document](https://docs.google.com/spreadsheets/d/1bQ9zZbW0mxLfMXDLQZT4W2M5Z-nv_6FZ1T5WC8Io8Zo/edit#gid=1626636507) and fill out your goal for Intermission. We will check in on these goals on the Monday of Week 1.  
 
-You will continue to add your weekly goals to that document every Monday throughout the inning. We'll set up a slackbot in #mod1_repeater_fam to remind you!
+You will continue to add your weekly goals to that document every Monday throughout the inning.
 
 ## Professional Development  
 Repeating the module is a great opportunity to solidify your technical AND professional development skills. As a repeater, you are not expected to re-do any of the async lessons or exit tickets. However, you are still expected to attend live (on Zoom) PD lessons!

--- a/lessons/module-2/archive/intro-to-axe.md
+++ b/lessons/module-2/archive/intro-to-axe.md
@@ -21,7 +21,7 @@ There are 3 billion (and counting) people using the internet.
 
 In America alone there are 57 million Americans with a disability (2012)
 
-consider the following statistics from the [Census Bureau's survey taken on July 25, 2012](http://www.interactiveaccessibility.com/accessibility-statistics)
+consider the following statistics from the [Census Bureau's survey taken on July 25, 2012](https://web.archive.org/web/20221005131811/http://www.interactiveaccessibility.com/accessibility-statistics)
 
 19.9 Million (8.2%) have difficulty lifting or grasping. This could, for example impact their use of a mouse or keyboard.
 

--- a/lessons/module-2/archive/testing-react.md
+++ b/lessons/module-2/archive/testing-react.md
@@ -709,7 +709,7 @@ First let's test that our state is updating whenever our input values change:
 ```
 
 Now for the tricky part. Our goal is to test that when the submit button is clicked, it calls the correct function it's supposed to. To do this, we'll need to do a couple things:
-* Stub in a [jest.fn()](http://facebook.github.io/jest/docs/jest-object.html#jestfnimplementation) in place of our actual function
+* Stub in a [jest.fn()](https://jestjs.io/docs/jest-object#jestfnimplementation) in place of our actual function
 * Find the specific button
 * Simulate a click event
 

--- a/lessons/module-2/archive/testing-react.md
+++ b/lessons/module-2/archive/testing-react.md
@@ -50,7 +50,7 @@ Just like `chai`, jest uses the `expect` keyword to check that values meet certa
 *Jest:* 
 `expect(something).toEqual(true)`
 
-The best way to check that we are writing tests correctly is to reference the docs. Let's check out the [expect documentation](https://facebook.github.io/jest/docs/expect.html#content) to take a look at some commons methods you may use for your testing React applications:
+The best way to check that we are writing tests correctly is to reference the docs. Let's check out the [expect documentation](https://jestjs.io/docs/expect) to take a look at some commons methods you may use for your testing React applications:
 
 #### Research
 

--- a/lessons/module-2/archive/testing-with-jest.md
+++ b/lessons/module-2/archive/testing-with-jest.md
@@ -532,7 +532,7 @@ First let's test that our state is updating whenever our input values change:
 ```
 
 Now for the tricky part. Our goal is to test that when the submit button is clicked, it calls the correct function it's supposed to. To do this, we'll need to do a couple things:
-* Stub in a [jest.fn()](http://facebook.github.io/jest/docs/jest-object.html#jestfnimplementation) in place of our actual function
+* Stub in a [jest.fn()](https://jestjs.io/docs/jest-object#jestfnimplementation) in place of our actual function
 * Find the specific button
 * Simulate a click event
 

--- a/lessons/module-2/archive/testing-with-jest.md
+++ b/lessons/module-2/archive/testing-with-jest.md
@@ -50,7 +50,7 @@ Some things to consider...
     * When you delete an item, is the count updated correctly? 
     
  
-The best way to check that we are writing tests correctly is to reference the docs. Let's check out the [expect documentation](https://facebook.github.io/jest/docs/expect.html#content) to take a look at some commons methods you may use for your testing React applications:
+The best way to check that we are writing tests correctly is to reference the docs. Let's check out the [expect documentation](https://jestjs.io/docs/expect) to take a look at some commons methods you may use for your testing React applications:
 
 ## Time to Test Our App component!
 

--- a/lessons/module-2/mod-2-repeater-hub.md
+++ b/lessons/module-2/mod-2-repeater-hub.md
@@ -5,7 +5,7 @@ title: Mod 2 Repeater Hub
 Welcome! Please read this entire page completely. Reach out to your instructors if you have any questions!
 
 ## Repeating Guidelines
-General information about repeating can be found [here](https://frontend.turing.edu/documents/repeat_guidelines_student_2020.pdf)
+General information about repeating can be found [here](https://docs.google.com/document/d/1B84KoDHytY1yVLxRK9CTc1eipCx2XOS7PVkxYU0p2zA/edit#heading=h.lzq0jebf1oau)
 
 ## Slack Channels
 Make sure you are part of the following channels:

--- a/lessons/module-2/oop-3-inheritance.md
+++ b/lessons/module-2/oop-3-inheritance.md
@@ -68,7 +68,7 @@ The basic inheritance syntax will look something like this:
 class Childclass extends Parentclass {...}
 ```
 
-Let's go back to our previous example with an Instructor used in the [last lesson](https://frontend.turing.edu/lessons/module-2/oop-2-objects-and-prototype-chain.html):
+Let's go back to our previous example with an Instructor used in the [last lesson](https://frontend.turing.edu/lessons/module-2/objects-and-prototype-chain.html):
 
 ```js
 class Instructor {

--- a/lessons/module-3/accessibility-deep-dive.md
+++ b/lessons/module-3/accessibility-deep-dive.md
@@ -31,7 +31,7 @@ There are 3 billion (and counting) people using the internet.
 
 In America alone there are 57 million Americans with a disability (2012)
 
-consider the following statistics from the [Census Bureau's survey taken on July 25, 2012](http://www.interactiveaccessibility.com/accessibility-statistics)
+consider the following statistics from the [Census Bureau's survey taken on July 25, 2012](https://web.archive.org/web/20221005131811/http://www.interactiveaccessibility.com/accessibility-statistics)
 
 - 19.9 Million (8.2%) have difficulty lifting or grasping. This could, for example impact their use of a mouse or keyboard.
 - 15.2 Million (6.3%) have a cognitive, mental, or emotional impairment.

--- a/lessons/module-3/grocery-list.md
+++ b/lessons/module-3/grocery-list.md
@@ -235,12 +235,12 @@ describe('Grocery', () => {
 });
 ```
 
-As previously mentioned, `create-react-app` uses [Jest](http://facebook.github.io/jest/) 
+As previously mentioned, `create-react-app` uses [Jest](https://jestjs.io/) 
 instead of Mocha. That said, you'll notice that the syntax is surprising similar. One 
 difference is that Jest includes its own expectation library which is similar to Chai's 
 `expect` syntax (as opposed to the `assert` syntax).  
 
-[Jest Assertions](https://facebook.github.io/jest/docs/api.html)  
+[Jest Assertions](https://jestjs.io/docs/api)  
 
 If you run `npm test` you should see your one test pass (two if you still have the 
 generic App test). You can keep this process running. The test suite will automatically 

--- a/lessons/module-3/grocery-list.md
+++ b/lessons/module-3/grocery-list.md
@@ -108,7 +108,7 @@ export default App;
 
 As we mentioned before, `create-react-app` has a built in testing framework that cannot 
 be changed without ejecting from the boilerplate. Luckily, it's a pretty awesome test 
-runner called `Jest`. [Read more about the Jest and React combo here](https://facebook.github.io/jest/docs/tutorial-react.html).
+runner called `Jest`. [Read more about the Jest and React combo here](https://jestjs.io/docs/tutorial-react).
 
 In order to run the tests, type `npm test`. Normally, our suite runs and then we return 
 to the command line. With Create React App, `npm test` starts up a server that is 

--- a/lessons/module-3/grocery-list.md
+++ b/lessons/module-3/grocery-list.md
@@ -441,7 +441,7 @@ it('should call the onPurchase prop when clicked', () => {
 - We likely want to pass in a grocery ID or grocery name to the `onPurchase` method so 
   we can keep track of what has been purchased. Can you add an assertion to the previous 
   test to check that `onPurchaseMock` was called with the correct arguments? 
-  ([Hint](https://facebook.github.io/jest/docs/expect.html#content))
+  ([Hint](https://jestjs.io/docs/expect))
 - Can you write the tests and implementation for the "Star" and "Remove" buttons?
 
 ### Testing a class method

--- a/lessons/module-3/unit-testing-react.md
+++ b/lessons/module-3/unit-testing-react.md
@@ -60,7 +60,7 @@ npm i
 
 ### Running Tests
 
-This application was built using `create-react-app`. The great thing about this is that it has a built in testing framework. This cannot be changed without ejecting from the boilerplate. Luckily, it's a pretty awesome test runner called `Jest`. [Read more about the Jest and React combo here](https://facebook.github.io/jest/docs/tutorial-react.html).
+This application was built using `create-react-app`. The great thing about this is that it has a built in testing framework. This cannot be changed without ejecting from the boilerplate. Luckily, it's a pretty awesome test runner called `Jest`. [Read more about the Jest and React combo here](https://jestjs.io/docs/tutorial-react).
 
 In order to run the tests, type `npm test`. Normally, our suite runs and then we return to the command line. With Create React App, `npm test` starts up a server that is constantly watching for changes. When you modify a file, the test suite will automatically rerun. Even better — by default, it will only watch files that have changed since the last time you made a git commit.
 

--- a/lessons/module-3/unit-testing-react.md
+++ b/lessons/module-3/unit-testing-react.md
@@ -150,7 +150,7 @@ describe('Card', () => {
 });
 ```
 
-As previously mentioned, `create-react-app` uses [Jest](http://facebook.github.io/jest/) instead of Mocha. That said, you'll notice that the syntax is surprising similar. One difference is that Jest includes its own expectation library which is similar to Chai's `expect` syntax (as opposed to the `assert` syntax).
+As previously mentioned, `create-react-app` uses [Jest](https://jestjs.io/) instead of Mocha. That said, you'll notice that the syntax is surprising similar. One difference is that Jest includes its own expectation library which is similar to Chai's `expect` syntax (as opposed to the `assert` syntax).
 
 [Jest Assertions](https://facebook.github.io/jest/docs/api.html)  
 

--- a/lessons/module-4/knex-postgres.md
+++ b/lessons/module-4/knex-postgres.md
@@ -393,7 +393,7 @@ exports.seed = async (knex) => {
 
 ## Fetching From the Database
 
-Let's write some express code to interact with our newly seeded database. [Set up a simple express server](https://frontend.turing.edu/lessons/module-4/intro-to-express.html) and we'll add some configuration to work with the knex database:
+Let's write some express code to interact with our newly seeded database. [Set up a simple express server](https://frontend.turing.edu/lessons/module-3/express) and we'll add some configuration to work with the knex database:
 
 ```js
 const environment = process.env.NODE_ENV || 'development';

--- a/lessons/module-4/knex-postgres.md
+++ b/lessons/module-4/knex-postgres.md
@@ -537,6 +537,6 @@ Write a GET request to retrieve all footnotes for a pre-existing paper. Verify i
 * What is seed data and what do we use it for?
 </section>
 
-### Instructor Resources
+<!-- ### Instructor Resources -->
 
-* [Step-by-Step Code Along Screenshots](https://github.com/turingschool/front-end-keys/tree/main/module-4/lesson-plans/knex)
+<!-- * [Step-by-Step Code Along Screenshots](https://github.com/turingschool/front-end-keys/tree/main/module-4/lesson-plans/knex) -->

--- a/lessons/module-4/knex-postgres.md
+++ b/lessons/module-4/knex-postgres.md
@@ -539,4 +539,4 @@ Write a GET request to retrieve all footnotes for a pre-existing paper. Verify i
 
 ### Instructor Resources
 
-* [Step-by-Step Code Along Screenshots](https://github.com/turingschool/front-end-keys/tree/master/module-4/lesson-plans/knex)
+* [Step-by-Step Code Along Screenshots](https://github.com/turingschool/front-end-keys/tree/main/module-4/lesson-plans/knex)

--- a/projects/module-1/intention-timer-pair.md
+++ b/projects/module-1/intention-timer-pair.md
@@ -201,12 +201,12 @@ To earn a given score, an application must meet the requirements listed in that 
 * **4:**
   * Functions and code are well-refactored and show developer empathy
   * There are no global variables aside from query selectors, `pastActivities` and `currentActivity`.
-  * Functions strictly observe [SRP](http://knnthvu.weebly.com/srp-and-dry.html) and do not exceed 10 lines
+  * Functions strictly observe [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle) and do not exceed 10 lines
   * Uses logical operators instead of if/else statements wherever applicable
   * There are no nested if/else statements
 * **3:**
   * Application uses event delegation correctly on dynamic elements
-  * Functions are [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) with a focus on [SRP](http://knnthvu.weebly.com/srp-and-dry.html)
+  * Functions are [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) with a focus on [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle)
   * Application demonstrates full separation of data-model and presentational logic (there is no DOM logic in the `Activity` class)
   * Application makes use of arguments and parameters to make functions more dynamic/reusable
 * **2:**

--- a/projects/module-1/number-guesser-pair.md
+++ b/projects/module-1/number-guesser-pair.md
@@ -166,7 +166,7 @@ Mobile layout:
   - All functions are less than 10 lines
 * **3:**
   * Application uses event delegation correctly on dynamic elements
-  * Functions are [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) with a focus on [SRP](http://knnthvu.weebly.com/srp-and-dry.html)
+  * Functions are [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) with a focus on [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle)
   * There are no nested if/else statements
 * **2:**
   * All parameters are used in their respective functions

--- a/projects/module-3/stretch.md
+++ b/projects/module-3/stretch.md
@@ -49,7 +49,6 @@ Create a summary (MVP) of what your application will do and who your application
 * [Cat Facts](https://alexwohlbruck.github.io/cat-facts/docs/)
 * [Marvel](https://developer.marvel.com/)
 * [Dad Jokes](https://icanhazdadjoke.com/api)
-* [Covid 19](https://covid19api.com/)
 * [IQAir - Real-Time Air Quality Forecast](https://www.iqair.com/us/air-pollution-data-api)
 * [eBird](https://documenter.getpostman.com/view/664302/S1ENwy59?version=latest)
 * [Dog CEO - Pictures of Dogs](https://dog.ceo/dog-api/)


### PR DESCRIPTION
**Description of changes made**
- I replaced a bunch of links that were giving 400 and 500 errors. 
- If the Wayback link exists, then I just replaced the link with that. Hopefully that will remain in existence for forever. 
- For other changes, I found the closest alternative option I could. Most of these links are in lessons that we don't actually teach, so I don't even know if anyone will notice that these links are different. 
- Some changes required updating the related instructions. For example, there was a SQL sandbox that no longer exists. Another website offers a nearly identical sandbox - but I had to update the names. 
- Some links felt redundant or have no replacement. These were removed. For example, a link to the community site was removed because the Front End Curriculum site already the community calendar supplied in many places. 

**Motivation for any changes**
- ticket asked me to

**Questions that you have for a reviewer**
- Do any of these links not make sense to you? Any of them not seem to match the content? 