### PR TITLE
667 rancid agile

### DIFF
--- a/projects/module-3/rancid-tomatillos-v3.md
+++ b/projects/module-3/rancid-tomatillos-v3.md
@@ -206,32 +206,40 @@ Check out this [article](https://developer.mozilla.org/en-US/docs/Learn/Common_q
 
 ### Iteration 5 - Differentiation Tracks
 
-The final days (last weekend and beginning of Week 3) of this project are designed to give you agency over your learning goals! As a team, consider your learning goals:  
+The final days (last weekend and beginning of Week 3) of this project are designed to give you some agency over your learning goals! As a team, consider your learning goals:  
 * What will best serve your team- and individual- learning goals?
 * What areas/concepts are still unclear?
 * What areas/concepts fit in with your professional goals?
 
-Decide as a team what to focus on and complete the Week 2 Deliverables (found below), choosing a new feature to implement or a thorough rubric-based refactor.  
+Decide as a team what to focus on and complete the Week 2 Deliverables (found below), choosing a new feature to implement or implementing a specific, thorough refactor. 
 
 <section class="call-to-action">
 ### WEEK 2 DELIVERABLES
 On Friday of Week 2, send a specific outline of features/work/goals to your instructors in the group DM. Include user stories. Do not begin work until you get the go-ahead from an instructor. (We may help you make your goal more specific or achievable.)
 
-Here are some ideas:
-* **Extremely thoroughly Refactoring:**
-  - Carefully compare your work to the rubric and refactor to ensure the work you're submitting is an excellent, thorough demonstration of your skill and compentency in React, Router and Cypress.  If you choose this option, be prepared to speak to specific refactoring you did. 
-* **Responsive Design:**
-  - Ensure your application is fully responsive across small, medium and large breakpoints
-* **More React and/or Router practice:**
-  - Add a search/filtering functionality for movies
-  - Give a user the ability to save movies to a favorites list. 
+Here are some ideas: 
+* **UI/UX Updates**
+  - Ensure your application is fully responsive across small, medium and large breakpoints, is fully tabbable and has a 95 score or higher on Lighthouse
+* **Add a Complex Feature**
+  - Create a new feature for the application that will bring value to the user and will allow you to challenge yourself, such as: 
+    - Allow users to create movie lists and save movies to those lists. Persisting this data to Local Storage
+    - Allow users to add notes to each movie. Persist this data to Local Storage.
+    - Implement a mock authentication system to allow a user to log in and see their profile. 
+    - Brainstorm your own new feature and check in with an instructor about it.
+    - Consider integrating with another API to bring additional information to your user. Some available APIs are: [OMDB](https://www.omdbapi.com/), [TMDB](https://developer.themoviedb.org/reference/intro/getting-started)
 * **More testing practice:**
   - Supplement your Cypress tests with a non-trivial amount of unit tests and integration tests by using the React Testing Library 
   - Implement 2-3 new concepts from the Cypress library that have not been covered in lessons (check out the following resources for ideas: [commands](https://docs.cypress.io/api/cypress-api/custom-commands), [component testing](https://docs.cypress.io/guides/component-testing/overview), [parallelization](https://docs.cypress.io/guides/guides/parallelization), [etc](https://docs.cypress.io/guides/overview/why-cypress))
 * **Push yourself** (extra learning if every member of the team feels SUPER CONFIDENT in everything React, Router, and testing)**:**
-  - Create your own Express microservice to store user ratings for movies; build FE functionality to use and display that service
-  - Create your own Express microservice to store user favorites; build FE functionality to use and display that service
-  - Create your own Express microservice to store which movies the user has watched; build FE functionality to use and display that service
+  - Implement a concept that will be covered later in the program or is not covered at all such as: 
+    - Redux (global state management)
+    - Context API (global state management)
+    - A Component Library such as Material-UI or React Bootstrap
+  - Create your own Express application to store user ratings for movies; build FE functionality to use and display that service
+  - Create your own Express application to store user favorites; build FE functionality to use and display that service
+  - Create your own Express application to store which movies the user has watched; build FE functionality to use and display that service
+  - Utilize Web Sockets to all users to comment on movies and see others' comments
+  - Implement Internationalization and Localization so that a user can view the app in multiple languages and see information presented in their preferred units. 
 
 You are welcome to come up with your own ideas too. Just run them by your PM.
 </section>

--- a/projects/module-3/rancid-tomatillos-v3.md
+++ b/projects/module-3/rancid-tomatillos-v3.md
@@ -219,7 +219,7 @@ On Friday of Week 2, send a specific outline of features/work/goals to your inst
 
 Here are some ideas: 
 * **UI/UX Updates**
-  - Ensure your application is fully responsive across small, medium and large breakpoints, is fully tabbable and has a 95 score or higher on Lighthouse
+  - Ensure your application is fully responsive across small, medium and large breakpoints, is fully tabbable and has a 95 score or higher on Lighthouse. User interactions should be intuitive and the app should include appropriate hover states and focus states
 * **Add a Complex Feature**
   - Create a new feature for the application that will bring value to the user and will allow you to challenge yourself, such as: 
     - Allow users to create movie lists and save movies to those lists. Persisting this data to Local Storage

--- a/projects/module-3/rancid-tomatillos-v3.md
+++ b/projects/module-3/rancid-tomatillos-v3.md
@@ -211,7 +211,7 @@ The final days (last weekend and beginning of Week 3) of this project are design
 * What areas/concepts are still unclear?
 * What areas/concepts fit in with your professional goals?
 
-Decide as a team what to focus on and complete the Week 2 Deliverables (found below), choosing a new feature to implement or implementing a specific, thorough refactor. 
+Decide as a team what to focus on and complete the Week 2 Deliverables (found below), choosing a new feature to implement, incorporating new concepts into the application, or building additional systems. 
 
 <section class="call-to-action">
 ### WEEK 2 DELIVERABLES

--- a/projects/module-3/rancid-tomatillos-v3.md
+++ b/projects/module-3/rancid-tomatillos-v3.md
@@ -12,6 +12,7 @@ This project is definitely not Rotten Tomatoes. Nor is it Netflix. Nor is it IMD
 * Test React components & asynchronous JS
 * Practice refactoring
 * Create a multi-page UX using Router
+* Incorporate agile practices such as daily stand-ups, retros, project boards
 
 ## Iterations
 
@@ -24,7 +25,11 @@ We've broken this project down into iterations. Please be sure to read them clos
 By the end of the day, Day 1:
 * The link to your repo (hint: use [Create-React-App](https://frontend.turing.edu/lessons/module-3/react-2-the-how.html) to start your project!)
 * The link to your DTR
-* The link to your Project Board with at least a few user stories entered  
+  * Be sure to discuss a meeting cadence for your group. In Agile projects, teams typically meet for short "stand-ups" where each member checks in regarding the following topics: 
+    * What is the state of your project so far? (Update your GitHub Project Board if necessary)
+    * What is each person working on today?
+    * Are there any blockers and what is your plan to get through the blockers? 
+* The link to your Project Board with at least a few user stories entered
 
 By the end of the day, Day 2:
 * A link to 2-3 pieces of design inspiration that you will aim to mimic

--- a/projects/module-3/rancid-tomatillos-v3.md
+++ b/projects/module-3/rancid-tomatillos-v3.md
@@ -219,7 +219,7 @@ On Friday of Week 2, send a specific outline of features/work/goals to your inst
 
 Here are some ideas: 
 * **UI/UX Updates**
-  - Ensure your application is fully responsive across small, medium and large breakpoints, is fully tabbable and has a 95 score or higher on Lighthouse. User interactions should be intuitive and the app should include appropriate hover states and focus states
+  - Ensure your application is fully responsive across small, medium and large breakpoints, is fully tabbable and has a 95 score or higher on Lighthouse. User interactions should be intuitive and should include interations, such as hover styles, that help the user use the app.
 * **Add a Complex Feature**
   - Create a new feature for the application that will bring value to the user and will allow you to challenge yourself, such as: 
     - Allow users to create movie lists and save movies to those lists. Persisting this data to Local Storage

--- a/projects/module-3/rancid-tomatillos-v3.md
+++ b/projects/module-3/rancid-tomatillos-v3.md
@@ -204,7 +204,7 @@ Check out this [article](https://developer.mozilla.org/en-US/docs/Learn/Common_q
 
 ---
 
-### Iteration 5 - Choose your own adventure
+### Iteration 5 - Differentiation Tracks
 
 The final days (last weekend and beginning of Week 3) of this project are designed to give you agency over your learning goals! As a team, consider your learning goals:  
 * What will best serve your team- and individual- learning goals?
@@ -215,15 +215,16 @@ Decide as a team what to focus on and complete the Week 2 Deliverables (found be
 
 <section class="call-to-action">
 ### WEEK 2 DELIVERABLES
-On Friday of Week 2, send a specific outline of features/work/goals to your instructors in the group DM. Please include user stories, too. Do not begin work until you get the go-ahead from an instructor. (We may help you make your goal more specific or achievable.)
+On Friday of Week 2, send a specific outline of features/work/goals to your instructors in the group DM. Include user stories. Do not begin work until you get the go-ahead from an instructor. (We may help you make your goal more specific or achievable.)
 
 Here are some ideas:
 * **Extremely thoroughly Refactoring:**
-  - Carefully compare your work to the rubric and refactor to ensure the work you're submitting is an excellent, thorough demonstration of your skill and compentency in React, Router and Cypress.  If you choose this option, be prepared to specific refactoring you did. 
+  - Carefully compare your work to the rubric and refactor to ensure the work you're submitting is an excellent, thorough demonstration of your skill and compentency in React, Router and Cypress.  If you choose this option, be prepared to speak to specific refactoring you did. 
 * **Responsive Design:**
   - Ensure your application is fully responsive across small, medium and large breakpoints
 * **More React and/or Router practice:**
   - Add a search/filtering functionality for movies
+  - Give a user the ability to save movies to a favorites list. 
 * **More testing practice:**
   - Supplement your Cypress tests with a non-trivial amount of unit tests and integration tests by using the React Testing Library 
   - Implement 2-3 new concepts from the Cypress library that have not been covered in lessons (check out the following resources for ideas: [commands](https://docs.cypress.io/api/cypress-api/custom-commands), [component testing](https://docs.cypress.io/guides/component-testing/overview), [parallelization](https://docs.cypress.io/guides/guides/parallelization), [etc](https://docs.cypress.io/guides/overview/why-cypress))

--- a/projects/module-3/rancid-tomatillos-v3.md
+++ b/projects/module-3/rancid-tomatillos-v3.md
@@ -239,7 +239,7 @@ Here are some ideas:
   - Create your own Express application to store user favorites; build FE functionality to use and display that service
   - Create your own Express application to store which movies the user has watched; build FE functionality to use and display that service
   - Utilize Web Sockets to all users to comment on movies and see others' comments
-  - Implement Internationalization and Localization so that a user can view the app in multiple languages and see information presented in their preferred units. 
+  - Implement Internationalization and Localization so that a user can view the app in multiple languages.
 
 You are welcome to come up with your own ideas too. Just run them by your PM.
 </section>

--- a/projects/module-3/rancid-tomatillos-v3.md
+++ b/projects/module-3/rancid-tomatillos-v3.md
@@ -226,7 +226,7 @@ Here are some ideas:
     - Allow users to add notes to each movie. Persist this data to Local Storage.
     - Implement a mock authentication system to allow a user to log in and see their profile. 
     - Brainstorm your own new feature and check in with an instructor about it.
-    - Consider integrating with another API to bring additional information to your user. Some available APIs are: [OMDB](https://www.omdbapi.com/), [TMDB](https://developer.themoviedb.org/reference/intro/getting-started)
+    - Consider integrating with another API to bring additional information to your user in the form of an additional feature. Some available APIs are: [OMDB](https://www.omdbapi.com/), [TMDB](https://developer.themoviedb.org/reference/intro/getting-started)
 * **More testing practice:**
   - Supplement your Cypress tests with a non-trivial amount of unit tests and integration tests by using the React Testing Library 
   - Implement 2-3 new concepts from the Cypress library that have not been covered in lessons (check out the following resources for ideas: [commands](https://docs.cypress.io/api/cypress-api/custom-commands), [component testing](https://docs.cypress.io/guides/component-testing/overview), [parallelization](https://docs.cypress.io/guides/guides/parallelization), [etc](https://docs.cypress.io/guides/overview/why-cypress))

--- a/projects/module-3/rancid-tomatillos-v3.md
+++ b/projects/module-3/rancid-tomatillos-v3.md
@@ -219,7 +219,7 @@ On Friday of Week 2, send a specific outline of features/work/goals to your inst
 
 Here are some ideas: 
 * **UI/UX Updates**
-  - Ensure your application is fully responsive across small, medium and large breakpoints, is fully tabbable and has a 95 score or higher on Lighthouse. User interactions should be intuitive and should include interations, such as hover styles, that help the user use the app.
+  - Ensure your application is fully responsive across small, medium and large breakpoints, is fully tabbable and has a 95 score or higher on Lighthouse. User interactions should be intuitive and should include interactions, such as hover styles, that help the user use the app.
 * **Add a Complex Feature**
   - Create a new feature for the application that will bring value to the user and will allow you to challenge yourself, such as: 
     - Allow users to create movie lists and save movies to those lists. Persisting this data to Local Storage


### PR DESCRIPTION
closes #667 

Agile Project Guidelines: https://spark-stick-6e4.notion.site/Agile-Projects-ffd6e66d80a146dbb60010facf92a455#d5c53556ba0c4196b36446f985542de5


**Description of changes made**
- the ticket requested changes to this project so that it matched up with the Agile Project Documentation. 
    - added agile objective to learning goals
    - added note about daily standups in the DTR deliverables ( seems like most groups do this already, but it's nice to make it explicit )
    - added another option to the "more React and/or Router practice" section of the CYOA to add more voice/choice and changed the title to match the Agile Project Documentation differentiation title, but we can change that. 
    - I changed the CYOA adventure items. I included tasks that involve new pages/routes alongside forms/click handlers. Because the data is so limited, it's hard to do much of anything else. I also added some more stretch options beyond just implementing an express backend, but I can remove those if we'd like. Anybody have any other challenging feature ideas? 

**Motivation for any changes**
- A couple of these seemed like good options for changes, but ultimately the project might already be aligned to the goals.
- Instructors expressed that students don't take the CYOA section seriously. 

**Questions that you have for a reviewer**

- What did you all have in mind for this ticket?
-  Does the CYOA section feel more challenging now? Do you think students will choose something reasonably challenging? 
- Maybe there's room for a retro between iterations 0-3 and 4-5? 